### PR TITLE
Changed variable names for readability + changed branch condition for…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,9 +116,9 @@ jobs:
       - script: |
           npm run build
         env:
-          REACT_APP_CLIENT_ID: $(REACT_APP_STAGING_CLIENT_ID)
-          REACT_APP_INSTRUMENTATION_KEY: $(REACT_APP_STAGING_INSTRUMENTATION_KEY)
-        displayName: 'Build static assets for staging'
+          REACT_APP_CLIENT_ID: $(REACT_APP_DEVTEST_CLIENT_ID)
+          REACT_APP_INSTRUMENTATION_KEY: $(REACT_APP_DEVTEST_INSTRUMENTATION_KEY)
+        displayName: 'Build static assets for dev-test release'
 
       - task: PowerShell@2
         displayName: 'Set version-number'
@@ -134,11 +134,11 @@ jobs:
 
       - script: |
           npm run build
-        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/dev'))
         env:
-          REACT_APP_CLIENT_ID: $(REACT_APP_PROD_CLIENT_ID)
-          REACT_APP_INSTRUMENTATION_KEY: $(REACT_APP_INSTRUMENTATION_KEY)
-        displayName: 'Build static assets for prod'
+          REACT_APP_CLIENT_ID: $(REACT_APP_STAGING_CLIENT_ID)
+          REACT_APP_INSTRUMENTATION_KEY: $(REACT_APP_STAGING_INSTRUMENTATION_KEY)
+        displayName: 'Build static assets for staging release'
 
       - task: CopyFiles@1
         displayName: 'Copy files to: $(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
## Overview

Currently, the pipeline has a condition to publish using production keys when the master branch involved in triggering the pipeline. It was changed to the dev branch for this repository in order to link the keys related to the staging website. The variables for the keys have been renamed for readability.  