### PR TITLE
AB#38033 MVP user/app mode UI

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -353,16 +353,12 @@ class App extends Component<IAppProps, IAppState> {
                   stackTokens,
                   classes,
                   minimised,
-                  this.toggleSidebar,
-                  permissionModeType,
-                  this.props.actions!.changeMode)}
+                  this.toggleSidebar)}
 
                 {!mobileScreen && appTitleDisplayOnFullScreen(
                   classes,
                   minimised,
-                  this.toggleSidebar,
-                  permissionModeType,
-                  this.props.actions!.changeMode)}
+                  this.toggleSidebar)}
 
                 <hr className={classes.separator} />
 

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -366,7 +366,7 @@ class App extends Component<IAppProps, IAppState> {
                 <hr className={classes.separator} />
 
                 {showSidebar && <>
-                  <Sidebar sampleHeaderText={sampleHeaderText} historyHeaderText={historyHeaderText} appHeaderText="Apps" />
+                  <Sidebar sampleHeaderText={sampleHeaderText} historyHeaderText={historyHeaderText} />
                 </>}
               </div>
             )}

--- a/src/app/views/app-sections/AppTitle.tsx
+++ b/src/app/views/app-sections/AppTitle.tsx
@@ -6,8 +6,6 @@ export function appTitleDisplayOnFullScreen(
   classes: any,
   minimised: any,
   toggleSidebar: Function,
-  permissionType: boolean,
-  changeMode: Function
 ): React.ReactNode {
 
   return <div style={{ display: 'flex', width: '100%' }}>
@@ -30,7 +28,7 @@ export function appTitleDisplayOnFullScreen(
     <div className={classes.graphExplorerLabelContainer} role={'heading'} aria-level={1}>
       {!minimised &&
         <>
-          {displayGraphLabel(classes, permissionType)}
+          {displayGraphLabel(classes)}
         </>}
     </div>
   </div>;
@@ -41,8 +39,6 @@ export function appTitleDisplayOnMobileScreen(
   classes: any,
   minimised: any,
   toggleSidebar: Function,
-  permissionType: boolean,
-  changeMode: Function
 ): React.ReactNode {
   return <Stack horizontal={true} disableShrink={true} tokens={stackTokens}>
     <>
@@ -54,16 +50,16 @@ export function appTitleDisplayOnMobileScreen(
         onClick={() => toggleSidebar()}
       />
       <div style={{ padding: 10 }} role={'heading'} aria-level={1}>
-        {displayGraphLabel(classes, permissionType)}
+        {displayGraphLabel(classes)}
       </div>
     </>
   </Stack>;
 }
 
-function displayGraphLabel(classes: any, permissionType: boolean): React.ReactNode {
+function displayGraphLabel(classes: any): React.ReactNode {
   return (
     <Label className={classes.graphExplorerLabel}>
-      Graph Explorer {permissionType ? "(as user)" : "(as Teams app)"}
+      Graph Explorer
     </Label>
   )
 }

--- a/src/app/views/app-sections/AppTitle.tsx
+++ b/src/app/views/app-sections/AppTitle.tsx
@@ -33,14 +33,6 @@ export function appTitleDisplayOnFullScreen(
           {displayGraphLabel(classes, permissionType)}
         </>}
     </div>
-    <div>
-      {
-        !minimised &&
-        <>
-          {permissionsModeButton(changeMode, permissionType)}
-        </>
-      }
-    </div>
   </div>;
 }
 
@@ -64,14 +56,6 @@ export function appTitleDisplayOnMobileScreen(
       <div style={{ padding: 10 }} role={'heading'} aria-level={1}>
         {displayGraphLabel(classes, permissionType)}
       </div>
-      <div>
-        {
-          !minimised &&
-          <>
-            {permissionsModeButton(changeMode, permissionType)}
-          </>
-        }
-      </div>
     </>
   </Stack>;
 }
@@ -81,14 +65,5 @@ function displayGraphLabel(classes: any, permissionType: boolean): React.ReactNo
     <Label className={classes.graphExplorerLabel}>
       Graph Explorer {permissionType ? "(as user)" : "(as Teams app)"}
     </Label>
-  )
-}
-
-function permissionsModeButton(changeMode: Function, permissionType: boolean) {
-  return (
-    <IconButton
-      iconProps={{ iconName: 'Cat' }}
-      onClick={() => changeMode(!permissionType)}
-      ariaLabel="button to switch between user and Teams app" />
   )
 }

--- a/src/app/views/authentication/profile/Profile.tsx
+++ b/src/app/views/authentication/profile/Profile.tsx
@@ -106,7 +106,7 @@ export class Profile extends Component<IProfileProps, IProfileState> {
     const persona: IPersonaSharedProps = {
       imageUrl: user.profileImageUrl,
       imageInitials: this.getInitials(user.displayName),
-      text: user.displayName,
+      text: user.displayName + ' ' + (this.props.permissionModeType ? messages['As user'] : messages['As Teams app']),
       secondaryText: user.emailAddress,
     };
 
@@ -190,7 +190,7 @@ function mapDispatchToProps(dispatch: Dispatch): object {
   };
 }
 
-function mapStateToProps({ sidebarProperties, theme, graphExplorerMode }: IRootState) {
+function mapStateToProps({ sidebarProperties, theme, graphExplorerMode, permissionModeType }: IRootState) {
   const mobileScreen = !!sidebarProperties.mobileScreen;
   const showSidebar = !!sidebarProperties.showSidebar;
 
@@ -198,7 +198,8 @@ function mapStateToProps({ sidebarProperties, theme, graphExplorerMode }: IRootS
     mobileScreen: !!sidebarProperties.mobileScreen,
     appTheme: theme,
     minimised: !mobileScreen && !showSidebar,
-    graphExplorerMode
+    graphExplorerMode,
+    permissionModeType
   };
 }
 

--- a/src/app/views/query-runner/request/permissions/Permission.tsx
+++ b/src/app/views/query-runner/request/permissions/Permission.tsx
@@ -174,7 +174,7 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
       }
     ];
 
-    const currentPermType = permissionModeType === DISPLAY_DELEGATED_PERMISSIONS;
+    const isCurrentPermTypeDelegated = permissionModeType === DISPLAY_DELEGATED_PERMISSIONS;
 
     if (!panel) {
       columns.push(
@@ -183,14 +183,14 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
           name: messages.Description,
           fieldName: 'consentDescription',
           isResizable: true,
-          minWidth: (tokenPresent) ? ((currentPermType) ? 400 : 800) : 600,
-          maxWidth: (tokenPresent) ? ((currentPermType) ? 600 : 1300) : 1000,
+          minWidth: (tokenPresent) ? ((isCurrentPermTypeDelegated) ? 400 : 800) : 600,
+          maxWidth: (tokenPresent) ? ((isCurrentPermTypeDelegated) ? 600 : 1300) : 1000,
           isMultiline: true
         }
       );
     }
 
-    if (currentPermType) {
+    if (isCurrentPermTypeDelegated) {
       columns.push(
         {
           key: 'isAdmin',

--- a/src/app/views/query-runner/request/permissions/Permission.tsx
+++ b/src/app/views/query-runner/request/permissions/Permission.tsx
@@ -188,29 +188,31 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
       );
     }
 
-    columns.push(
-      {
-        key: 'isAdmin',
-        isResizable: true,
-        name: messages['Admin consent required'],
-        fieldName: 'isAdmin',
-        minWidth: (tokenPresent && permissionModeType === DISPLAY_DELEGATED_PERMISSIONS) ? 150 : 200,
-        maxWidth: (tokenPresent && permissionModeType === DISPLAY_DELEGATED_PERMISSIONS) ? 200 : 300,
-        ariaLabel: translateMessage('Administrator permission')
-      }
-    );
-
-    if (tokenPresent && permissionModeType === DISPLAY_DELEGATED_PERMISSIONS) {
+    if (permissionModeType === DISPLAY_DELEGATED_PERMISSIONS) {
       columns.push(
         {
-          key: 'consented',
-          name: messages.Status,
-          isResizable: false,
-          fieldName: 'consented',
-          minWidth: 100,
-          maxWidth: 100
+          key: 'isAdmin',
+          isResizable: true,
+          name: messages['Admin consent required'],
+          fieldName: 'isAdmin',
+          minWidth: (tokenPresent) ? 150 : 200,
+          maxWidth: (tokenPresent) ? 200 : 300,
+          ariaLabel: translateMessage('Administrator permission')
         }
       );
+
+      if (tokenPresent) {
+        columns.push(
+          {
+            key: 'consented',
+            name: messages.Status,
+            isResizable: false,
+            fieldName: 'consented',
+            minWidth: 100,
+            maxWidth: 100
+          }
+        );
+      }
     }
     return columns;
   }

--- a/src/app/views/query-runner/request/permissions/Permission.tsx
+++ b/src/app/views/query-runner/request/permissions/Permission.tsx
@@ -174,6 +174,8 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
       }
     ];
 
+    const currentPermType = permissionModeType === DISPLAY_DELEGATED_PERMISSIONS;
+
     if (!panel) {
       columns.push(
         {
@@ -181,14 +183,14 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
           name: messages.Description,
           fieldName: 'consentDescription',
           isResizable: true,
-          minWidth: (tokenPresent && permissionModeType === DISPLAY_DELEGATED_PERMISSIONS) ? 400 : 600,
-          maxWidth: (tokenPresent && permissionModeType === DISPLAY_DELEGATED_PERMISSIONS) ? 600 : 1000,
+          minWidth: (tokenPresent) ? ((currentPermType) ? 400 : 800) : 600,
+          maxWidth: (tokenPresent) ? ((currentPermType) ? 600 : 1300) : 1000,
           isMultiline: true
         }
       );
     }
 
-    if (permissionModeType === DISPLAY_DELEGATED_PERMISSIONS) {
+    if (currentPermType) {
       columns.push(
         {
           key: 'isAdmin',

--- a/src/app/views/query-runner/request/permissions/Permission.tsx
+++ b/src/app/views/query-runner/request/permissions/Permission.tsx
@@ -18,6 +18,7 @@ import { componentNames, telemetry } from '../../../../../telemetry';
 import { IPermission, IPermissionProps, IPermissionState } from '../../../../../types/permissions';
 import { IRootState } from '../../../../../types/root';
 import * as permissionActionCreators from '../../../../services/actions/permissions-action-creator';
+import { DISPLAY_DELEGATED_PERMISSIONS } from '../../../../services/graph-constants';
 import { translateMessage } from '../../../../utils/translate-messages';
 import { classNames } from '../../../classnames';
 import { convertVhToPx } from '../../../common/dimensions-adjustment';
@@ -159,6 +160,7 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
       tokenPresent,
       panel,
       intl: { messages },
+      permissionModeType
     }: any = this.props;
 
     const columns: IColumn[] = [
@@ -179,8 +181,8 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
           name: messages.Description,
           fieldName: 'consentDescription',
           isResizable: true,
-          minWidth: (tokenPresent) ? 400 : 600,
-          maxWidth: (tokenPresent) ? 600 : 1000,
+          minWidth: (tokenPresent && permissionModeType === DISPLAY_DELEGATED_PERMISSIONS) ? 400 : 600,
+          maxWidth: (tokenPresent && permissionModeType === DISPLAY_DELEGATED_PERMISSIONS) ? 600 : 1000,
           isMultiline: true
         }
       );
@@ -192,13 +194,13 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
         isResizable: true,
         name: messages['Admin consent required'],
         fieldName: 'isAdmin',
-        minWidth: (tokenPresent) ? 150 : 200,
-        maxWidth: (tokenPresent) ? 200 : 300,
+        minWidth: (tokenPresent && permissionModeType === DISPLAY_DELEGATED_PERMISSIONS) ? 150 : 200,
+        maxWidth: (tokenPresent && permissionModeType === DISPLAY_DELEGATED_PERMISSIONS) ? 200 : 300,
         ariaLabel: translateMessage('Administrator permission')
       }
     );
 
-    if (tokenPresent) {
+    if (tokenPresent && permissionModeType === DISPLAY_DELEGATED_PERMISSIONS) {
       columns.push(
         {
           key: 'consented',
@@ -276,14 +278,15 @@ export class Permission extends Component<IPermissionProps, IPermissionState> {
   }
 }
 
-function mapStateToProps({ sampleQuery, scopes, authToken, consentedScopes, dimensions, permissionsPanelOpen }: IRootState) {
+function mapStateToProps({ sampleQuery, scopes, authToken, consentedScopes, dimensions, permissionsPanelOpen, permissionModeType }: IRootState) {
   return {
     sample: sampleQuery,
     scopes,
     tokenPresent: authToken.token,
     consentedScopes,
     dimensions,
-    permissionsPanelOpen
+    permissionsPanelOpen,
+    permissionModeType
   };
 }
 

--- a/src/app/views/query-runner/request/permissions/TabList.tsx
+++ b/src/app/views/query-runner/request/permissions/TabList.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { IPermission } from '../../../../../types/permissions';
 import { IRootState } from '../../../../../types/root';
 import { togglePermissionsPanel } from '../../../../services/actions/permissions-panel-action-creator';
-import { DISPLAY_APPLICATION_PERMISSIONS, DISPLAY_DELEGATED_PERMISSIONS, RSC_PERMISSIONS_ENDINGS } from '../../../../services/graph-constants';
+import { DISPLAY_APPLICATION_PERMISSIONS, RSC_PERMISSIONS_ENDINGS } from '../../../../services/graph-constants';
 import { setConsentedStatus } from './util';
 
 interface ITabList {

--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -27,13 +27,14 @@ import { ISettingsProps } from '../../../types/settings';
 import { signOut } from '../../services/actions/auth-action-creators';
 import { consentToScopes } from '../../services/actions/permissions-action-creator';
 import { togglePermissionsPanel } from '../../services/actions/permissions-panel-action-creator';
+import { changeMode } from '../../services/actions/permission-mode-action-creator';
 import { changeTheme } from '../../services/actions/theme-action-creator';
 import { Permission } from '../query-runner/request/permissions';
 
 
 function Settings(props: ISettingsProps) {
   const dispatch = useDispatch();
-  const { permissionsPanelOpen, authToken, theme: appTheme } = useSelector((state: IRootState) => state);
+  const { permissionsPanelOpen, authToken, theme: appTheme, permissionModeType } = useSelector((state: IRootState) => state);
   const authenticated = authToken.token;
   const [themeChooserDialogHidden, hideThemeChooserDialog] = useState(true);
   const [items, setItems] = useState([]);
@@ -82,6 +83,14 @@ function Settings(props: ISettingsProps) {
     if (authenticated) {
       menuItems.push(
         {
+          key: 'switch-user-app-mode',
+          text: messages[permissionModeType ? "Use Explorer as sample Teams application" : "Use Explorer as logged-in user"],
+          iconProps: {
+            iconName: permissionModeType ? "TeamsLogo" : "Contact",
+          },
+          onClick: () => handleChangeMode(permissionModeType),
+        },
+        {
           key: 'view-all-permissions',
           text: messages['view all permissions'],
           iconProps: {
@@ -100,7 +109,7 @@ function Settings(props: ISettingsProps) {
       );
     }
     setItems(menuItems);
-  }, [authenticated]);
+  }, [authenticated, permissionModeType]);
 
   const toggleThemeChooserDialogState = () => {
     let hidden = themeChooserDialogHidden;
@@ -111,6 +120,10 @@ function Settings(props: ISettingsProps) {
       {
         ComponentName: componentNames.THEME_CHANGE_BUTTON
       });
+  };
+
+  const handleChangeMode = (permissionModeType: boolean) => {
+    dispatch(changeMode(!permissionModeType));
   };
 
   const handleSignOut = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,7 +18,6 @@ import { getAuthTokenSuccess, getConsentedScopesSuccess } from './app/services/a
 import { setDevxApiUrl } from './app/services/actions/devxApi-action-creators';
 import { setGraphExplorerMode } from './app/services/actions/explorer-mode-action-creator';
 import { addHistoryItem } from './app/services/actions/request-history-action-creators';
-import { changeMode } from './app/services/actions/permission-mode-action-creator';
 import { changeThemeSuccess } from './app/services/actions/theme-action-creator';
 import { isValidHttpsUrl } from './app/utils/external-link-validation';
 import App from './app/views/App';

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -357,5 +357,7 @@
   "Click here to follow the link": "Click here to follow the link",
   "Signing you out...": "Signing you out...",
   "As user": "(as user)",
-  "As Teams app": "(as Teams app)"
+  "As Teams app": "(as Teams app)",
+  "Use Explorer as sample Teams application": "Use Explorer as sample Teams application",
+  "Use Explorer as logged-in user": "Use Explorer as logged-in user"
 }

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -295,7 +295,7 @@
   "Admin consent required": "Admin consent required",
   "Consent": "Consent",
   "permissions required to run the query": "One of the following delegated permissions is required to run the query. Select a permission and click Consent.",
-  "application permissions required to run the query": "One of the following resource specific consent permissions is required to run the query. Select a permission and click Consent.",
+  "application permissions required to run the query": "One of the following resource specific consent permissions is required to run the query.",
   "tab": " tab",
   "View the": " View the",
   "viewing a cached set": "You are viewing a cached set of samples because of a network connection failure.",

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -2,7 +2,7 @@ import { ITheme } from 'office-ui-fabric-react';
 
 export interface IProfileProps {
     intl: {
-      message: object;
+        message: object;
     };
     theme?: ITheme;
     styles?: object;
@@ -11,6 +11,7 @@ export interface IProfileProps {
         getProfileInfo: Function;
         signOut: Function;
     };
+    permissionModeType: boolean;
 }
 
 export interface IProfileState {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,7 +1,9 @@
 export interface ISettingsProps {
   actions?: {
+    changeMode: Function;
     signOut: Function;
     changeTheme: Function;
+    togglePermissionsPanel: Function;
     consentToScopes: Function;
   };
   intl?: {


### PR DESCRIPTION
ADO Board Link: [Task #38033](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_sprints/taskboard/GI21%20-%20Graph%20Explorer/Intern%20GitHub/Y21-S/04?workitem=38033)

## Overview

* We needed to remove the temporary switch mode button and move its functionality into the Profile dropdown menu.
* The dropdown menu option needed to change based on which mode you're in (i.e. it needs to display app mode when you're in user mode and vice versa).
* We needed to to remove the `Status` (Consent buttons) and `Admin consent required` columns when in app mode, since we cannot consent RSC permissions from the Graph Explorer web app.
* We needed to move the `(as user)`/`(as Teams app)` identifiers from the Graph Explorer title section to the Profile section.
* We needed to remove code from https://github.com/LokiLabs/microsoft-graph-explorer-v4/pull/7 that is no longer used.

### Demo

See `Testing Instructions`.

### Notes

* This branch was renamed when it was in a draft PR (https://github.com/LokiLabs/microsoft-graph-explorer-v4/pull/11): as a result, the previous draft PR was closed. This PR contains comments that point to comments on the previous draft PR.
* We received feedback from the Teams Graph sponsor team that some of our MVP UI will have to be changed for the final product, but that will be handled after MVP.

## Testing Instructions

* Check out this branch
* Run `nvm use 14.0.0`
* Run `npm install && npm start`

**Demo steps:**

Step 1
* When you're not logged in, click the `...` button in the Authentication section. You should see 3 options, as shown below.
* Click the `Modify permissions (Preview)` tab. You should see 3 columns, `Permission`, `Description`, and `Admin consent required`.

![image](https://user-images.githubusercontent.com/46834951/124007543-b0d5f380-d998-11eb-9b13-71e465ed614e.png)

Step 2
* After logging in, you should see the words `(as user)` appear next to your name, instead of  `(as user)` appearing next to `Graph Explorer` as in https://github.com/LokiLabs/microsoft-graph-explorer-v4/pull/7.
* In the `Sample queries` section, scroll down to `Microsoft Teams` and select `POST create channel`, as shown below (I'm using this sample query as an example because it has delegated and resource-specific consent (RSC) permissions).
* Click the `Modify permissions (Preview)` tab. You should now see 4 columns, including a new `Status` column with `Consent` buttons.
* The tab should also say "One of the following **delegated** permissions is required to run the query."

![image](https://user-images.githubusercontent.com/46834951/124012697-a9b1e400-d99e-11eb-8b9a-e665276cb8b5.png)

Step 3
* Click the `...` button again in your Profile section. You should now see 6 options, with `Use Explorer as sample Teams application` third from the bottom, as seen below. Click that option.

![image](https://user-images.githubusercontent.com/46834951/124012994-feedf580-d99e-11eb-9983-8364247f1604.png)

Step 4
* The words `(as Teams app)` should now appear next to your name.
* The `Modify permissions (Preview)` tab should now say "One of the following **resource specific consent** permissions is required to run the query."
* The tab should now have 2 columns, with the `Admin consent required` and `Status` column removed.

![image](https://user-images.githubusercontent.com/46834951/124016023-6c4f5580-d9a2-11eb-9ec3-ef4df885fbc3.png)

Step 5
* Click the `...` button again in your Profile section. You should still see 6 options, but the third option from the button should now say `Use Explorer as logged-in user`. Click that option.

![image](https://user-images.githubusercontent.com/46834951/124015117-8fc5d080-d9a1-11eb-8123-7d33373519b3.png)

Step 6
* You should now be in the same state as Step 2.