### PR TITLE
AB#38602 error message switch modes

### DIFF
--- a/src/app/services/graph-constants.ts
+++ b/src/app/services/graph-constants.ts
@@ -14,3 +14,4 @@ export enum PERMS_SCOPE {
 export const DISPLAY_DELEGATED_PERMISSIONS = true;
 export const DISPLAY_APPLICATION_PERMISSIONS = false;
 export const RSC_PERMISSIONS_ENDINGS = [".Group", ".Chat"];
+export const SWITCH_MODE_NOTICE = 5

--- a/src/app/services/graph-constants.ts
+++ b/src/app/services/graph-constants.ts
@@ -16,3 +16,4 @@ export enum PERMISSION_MODE_TYPE {
     User
 }
 export const RSC_PERMISSIONS_ENDINGS = [".Group", ".Chat"];
+export const SWITCH_MODE_NOTICE = 5

--- a/src/app/services/reducers/permission-mode-reducer.ts
+++ b/src/app/services/reducers/permission-mode-reducer.ts
@@ -15,4 +15,3 @@ export function permissionModeType(state: boolean = DISPLAY_DELEGATED_PERMISSION
             return state;
     }
 }
-

--- a/src/app/services/reducers/permission-mode-reducer.ts
+++ b/src/app/services/reducers/permission-mode-reducer.ts
@@ -15,4 +15,3 @@ export function permissionModeType(state: PERMISSION_MODE_TYPE = PERMISSION_MODE
             return state;
     }
 }
-

--- a/src/app/services/reducers/permission-mode-reducer.ts
+++ b/src/app/services/reducers/permission-mode-reducer.ts
@@ -16,6 +16,3 @@ export function permissionModeType(state: boolean = DISPLAY_DELEGATED_PERMISSION
     }
 }
 
-export function switchPermissionMode(state = " ", action: IAction) {
-
-}

--- a/src/app/services/reducers/permission-mode-reducer.ts
+++ b/src/app/services/reducers/permission-mode-reducer.ts
@@ -15,3 +15,7 @@ export function permissionModeType(state: PERMISSION_MODE_TYPE = PERMISSION_MODE
             return state;
     }
 }
+
+export function switchPermissionMode(state = " ", action: IAction) {
+
+}

--- a/src/app/services/reducers/permission-mode-reducer.ts
+++ b/src/app/services/reducers/permission-mode-reducer.ts
@@ -16,6 +16,3 @@ export function permissionModeType(state: PERMISSION_MODE_TYPE = PERMISSION_MODE
     }
 }
 
-export function switchPermissionMode(state = " ", action: IAction) {
-
-}

--- a/src/app/services/reducers/permission-mode-reducer.ts
+++ b/src/app/services/reducers/permission-mode-reducer.ts
@@ -15,3 +15,7 @@ export function permissionModeType(state: boolean = DISPLAY_DELEGATED_PERMISSION
             return state;
     }
 }
+
+export function switchPermissionMode(state = " ", action: IAction) {
+
+}

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -18,6 +18,7 @@ import { ISharedQueryParams } from '../../types/share-query';
 import { ISidebarProps } from '../../types/sidebar';
 import * as authActionCreators from '../services/actions/auth-action-creators';
 import { runQuery } from '../services/actions/query-action-creators';
+import { fetchScopes } from '../services/actions/permissions-action-creator';
 import { setSampleQuery } from '../services/actions/query-input-action-creators';
 import { clearQueryStatus } from '../services/actions/query-status-action-creator';
 import { changeMode } from '../services/actions/permission-mode-action-creator';
@@ -62,6 +63,7 @@ interface IAppProps {
     signIn: Function;
     storeScopes: Function;
     changeMode: Function;
+    fetchScopes: Function;
   };
 }
 
@@ -86,6 +88,7 @@ class App extends Component<IAppProps, IAppState> {
   public componentDidMount = async () => {
     this.displayToggleButton(this.mediaQueryList);
     this.mediaQueryList.addListener(this.displayToggleButton);
+    this.props.actions!.fetchScopes();
 
     const urlParams = new URLSearchParams(window.location.search);
     const sessionId = urlParams.get('sid');
@@ -305,7 +308,7 @@ class App extends Component<IAppProps, IAppState> {
   public render() {
     const classes = classNames(this.props);
     const { authenticated, graphExplorerMode, queryState, minimised, termsOfUse, sampleQuery,
-      actions, sidebarProperties, permissionModeType, intl: { messages } }: any = this.props;
+      actions, sidebarProperties, permissionModeType, intl: { messages }, scopes }: any = this.props;
     const query = createShareLink(sampleQuery, authenticated);
     const sampleHeaderText = messages['Sample Queries'];
     // tslint:disable-next-line:no-string-literal
@@ -377,7 +380,7 @@ class App extends Component<IAppProps, IAppState> {
                 <div style={{ marginBottom: 8 }}>
                   <QueryRunner onSelectVerb={this.handleSelectVerb} />
                 </div>
-                {statusMessages(queryState, sampleQuery, actions)}
+                {statusMessages(queryState, sampleQuery, actions, scopes, permissionModeType)}
                 {termsOfUseMessage(termsOfUse, actions, classes, geLocale)}
                 {
                   // @ts-ignore
@@ -393,7 +396,7 @@ class App extends Component<IAppProps, IAppState> {
 }
 
 const mapStateToProps = ({ sidebarProperties, theme,
-  queryRunnerStatus, profile, sampleQuery, termsOfUse, authToken, graphExplorerMode, permissionModeType
+  queryRunnerStatus, profile, sampleQuery, termsOfUse, authToken, graphExplorerMode, permissionModeType, scopes
 }: IRootState) => {
   const mobileScreen = !!sidebarProperties.mobileScreen;
   const showSidebar = !!sidebarProperties.showSidebar;
@@ -409,7 +412,8 @@ const mapStateToProps = ({ sidebarProperties, theme,
     minimised: !mobileScreen && !showSidebar,
     sampleQuery,
     authenticated: !!authToken.token,
-    permissionModeType
+    permissionModeType,
+    scopes
   };
 };
 
@@ -422,6 +426,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
       setSampleQuery,
       toggleSidebar,
       changeMode,
+      fetchScopes,
       ...authActionCreators,
       changeTheme: (newTheme: string) => {
         return (disp: Function) => disp(changeThemeSuccess(newTheme));

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -18,6 +18,7 @@ import { ISharedQueryParams } from '../../types/share-query';
 import { ISidebarProps } from '../../types/sidebar';
 import * as authActionCreators from '../services/actions/auth-action-creators';
 import { runQuery } from '../services/actions/query-action-creators';
+import { fetchScopes } from '../services/actions/permissions-action-creator';
 import { setSampleQuery } from '../services/actions/query-input-action-creators';
 import { clearQueryStatus } from '../services/actions/query-status-action-creator';
 import { changeMode } from '../services/actions/permission-mode-action-creator';
@@ -62,6 +63,7 @@ interface IAppProps {
     signIn: Function;
     storeScopes: Function;
     changeMode: Function;
+    fetchScopes: Function;
   };
 }
 
@@ -86,6 +88,7 @@ class App extends Component<IAppProps, IAppState> {
   public componentDidMount = async () => {
     this.displayToggleButton(this.mediaQueryList);
     this.mediaQueryList.addListener(this.displayToggleButton);
+    this.props.actions!.fetchScopes();
 
     const urlParams = new URLSearchParams(window.location.search);
     const sessionId = urlParams.get('sid');
@@ -305,7 +308,7 @@ class App extends Component<IAppProps, IAppState> {
   public render() {
     const classes = classNames(this.props);
     const { authenticated, graphExplorerMode, queryState, minimised, termsOfUse, sampleQuery,
-      actions, sidebarProperties, permissionModeType, intl: { messages } }: any = this.props;
+      actions, sidebarProperties, permissionModeType, intl: { messages }, scopes }: any = this.props;
     const query = createShareLink(sampleQuery, authenticated);
     const sampleHeaderText = messages['Sample Queries'];
     // tslint:disable-next-line:no-string-literal
@@ -381,7 +384,7 @@ class App extends Component<IAppProps, IAppState> {
                 <div style={{ marginBottom: 8 }}>
                   <QueryRunner onSelectVerb={this.handleSelectVerb} permissionModeType={permissionModeType} />
                 </div>
-                {statusMessages(queryState, sampleQuery, actions)}
+                {statusMessages(queryState, sampleQuery, actions, scopes, permissionModeType)}
                 {termsOfUseMessage(termsOfUse, actions, classes, geLocale)}
                 {
                   // @ts-ignore
@@ -397,7 +400,7 @@ class App extends Component<IAppProps, IAppState> {
 }
 
 const mapStateToProps = ({ sidebarProperties, theme,
-  queryRunnerStatus, profile, sampleQuery, termsOfUse, authToken, graphExplorerMode, permissionModeType
+  queryRunnerStatus, profile, sampleQuery, termsOfUse, authToken, graphExplorerMode, permissionModeType, scopes
 }: IRootState) => {
   const mobileScreen = !!sidebarProperties.mobileScreen;
   const showSidebar = !!sidebarProperties.showSidebar;
@@ -413,7 +416,8 @@ const mapStateToProps = ({ sidebarProperties, theme,
     minimised: !mobileScreen && !showSidebar,
     sampleQuery,
     authenticated: !!authToken.token,
-    permissionModeType
+    permissionModeType,
+    scopes
   };
 };
 
@@ -426,6 +430,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
       setSampleQuery,
       toggleSidebar,
       changeMode,
+      fetchScopes,
       ...authActionCreators,
       changeTheme: (newTheme: string) => {
         return (disp: Function) => disp(changeThemeSuccess(newTheme));

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -375,7 +375,7 @@ class App extends Component<IAppProps, IAppState> {
 
               {displayContent && <>
                 <div style={{ marginBottom: 8 }}>
-                  <QueryRunner onSelectVerb={this.handleSelectVerb} permissionModeType={permissionModeType} />
+                  <QueryRunner onSelectVerb={this.handleSelectVerb} />
                 </div>
                 {statusMessages(queryState, sampleQuery, actions)}
                 {termsOfUseMessage(termsOfUse, actions, classes, geLocale)}

--- a/src/app/views/app-sections/StatusMessages.tsx
+++ b/src/app/views/app-sections/StatusMessages.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { IPermission } from '../../../types/permissions';
 
 import { IQuery } from '../../../types/query-runner';
-import { PERMISSION_MODE_TYPE, GRAPH_URL, RSC_PERMISSIONS_ENDINGS } from '../../services/graph-constants';
+import { PERMISSION_MODE_TYPE, GRAPH_URL, RSC_PERMISSIONS_ENDINGS, SWITCH_MODE_NOTICE } from '../../services/graph-constants';
 import {
   convertArrayToObject, extractUrl, getMatchesAndParts,
   matchIncludesLink, replaceLinks
@@ -65,7 +65,7 @@ export function statusMessages(queryState: any, sampleQuery: IQuery, actions: an
     const noPerms = filteredScopes.length === 0;
 
     return (
-      <MessageBar messageBarType={noPerms ? 5 : messageType}
+      <MessageBar messageBarType={noPerms ? SWITCH_MODE_NOTICE : messageType}
         isMultiline={true}
         onDismiss={actions.clearQueryStatus}
         dismissButtonAriaLabel='Close'

--- a/src/app/views/app-sections/StatusMessages.tsx
+++ b/src/app/views/app-sections/StatusMessages.tsx
@@ -1,15 +1,16 @@
 import { Link, MessageBar } from 'office-ui-fabric-react';
 import React, { Fragment } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { IPermission } from '../../../types/permissions';
 
 import { IQuery } from '../../../types/query-runner';
-import { GRAPH_URL } from '../../services/graph-constants';
+import { PERMISSION_MODE_TYPE, GRAPH_URL, RSC_PERMISSIONS_ENDINGS } from '../../services/graph-constants';
 import {
   convertArrayToObject, extractUrl, getMatchesAndParts,
   matchIncludesLink, replaceLinks
 } from '../../utils/status-message';
 
-export function statusMessages(queryState: any, sampleQuery: IQuery, actions: any) {
+export function statusMessages(queryState: any, sampleQuery: IQuery, actions: any, scopes: any, permissionModeType: PERMISSION_MODE_TYPE) {
   function displayStatusMessage(message: string, urls: any) {
     const { matches, parts } = getMatchesAndParts(message);
 
@@ -51,16 +52,31 @@ export function statusMessages(queryState: any, sampleQuery: IQuery, actions: an
       message = replaceLinks(status);
       urls = convertArrayToObject(extractedUrls);
     }
+    const isRSC = (permission: IPermission) => {
+      return RSC_PERMISSIONS_ENDINGS.some((ending) => permission.value.indexOf(ending) !== -1)
+    }
+
+    const filterPermissionsForRSC = () => {
+      return permissionModeType === PERMISSION_MODE_TYPE.TeamsApp ? permissions.filter(isRSC) : permissions;
+    }
+
+    const permissions: IPermission[] = scopes.hasUrl ? scopes.data : [];
+    const filteredScopes = filterPermissionsForRSC();
+    const noPerms = filteredScopes.length === 0;
 
     return (
-      <MessageBar messageBarType={messageType}
+      <MessageBar messageBarType={noPerms ? 5 : messageType}
         isMultiline={true}
         onDismiss={actions.clearQueryStatus}
         dismissButtonAriaLabel='Close'
         aria-live={'assertive'}>
-        {`${statusText} - `}{displayStatusMessage(message, urls)}
 
-        {duration && <>
+        {noPerms && permissionModeType === PERMISSION_MODE_TYPE.TeamsApp && <FormattedMessage id='delegated user mode' />}
+        {noPerms && permissionModeType === PERMISSION_MODE_TYPE.User && <FormattedMessage id='application mode' />}
+
+        {!noPerms && `${statusText} - `}{!noPerms && displayStatusMessage(message, urls)}
+
+        {!noPerms && duration && <>
           {` - ${duration}`}<FormattedMessage id='milliseconds' />
         </>}
 

--- a/src/app/views/app-sections/StatusMessages.tsx
+++ b/src/app/views/app-sections/StatusMessages.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { IPermission } from '../../../types/permissions';
 
 import { IQuery } from '../../../types/query-runner';
-import { DISPLAY_APPLICATION_PERMISSIONS, DISPLAY_DELEGATED_PERMISSIONS, GRAPH_URL, RSC_PERMISSIONS_ENDINGS } from '../../services/graph-constants';
+import { DISPLAY_APPLICATION_PERMISSIONS, DISPLAY_DELEGATED_PERMISSIONS, GRAPH_URL, RSC_PERMISSIONS_ENDINGS, SWITCH_MODE_NOTICE } from '../../services/graph-constants';
 import {
   convertArrayToObject, extractUrl, getMatchesAndParts,
   matchIncludesLink, replaceLinks
@@ -65,7 +65,7 @@ export function statusMessages(queryState: any, sampleQuery: IQuery, actions: an
     const noPerms = filteredScopes.length === 0;
 
     return (
-      <MessageBar messageBarType={noPerms ? 5 : messageType}
+      <MessageBar messageBarType={noPerms ? SWITCH_MODE_NOTICE : messageType}
         isMultiline={true}
         onDismiss={actions.clearQueryStatus}
         dismissButtonAriaLabel='Close'

--- a/src/app/views/query-runner/QueryRunner.tsx
+++ b/src/app/views/query-runner/QueryRunner.tsx
@@ -152,7 +152,6 @@ export class QueryRunner extends Component<
               <Request
                 handleOnEditorChange={this.handleOnEditorChange}
                 sampleQuery={this.props.sampleQuery}
-                permissionModeType={this.props.permissionModeType}
               />
             }
           </div>

--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -34,6 +34,7 @@ import * as queryActionCreators from '../../../services/actions/query-action-cre
 import * as queryInputActionCreators from '../../../services/actions/query-input-action-creators';
 import * as queryStatusActionCreators from '../../../services/actions/query-status-action-creator';
 import * as samplesActionCreators from '../../../services/actions/samples-action-creators';
+import { fetchScopes } from '../../../services/actions/permissions-action-creator';
 import { GRAPH_URL } from '../../../services/graph-constants';
 import { getStyleFor } from '../../../utils/badge-color';
 import { validateExternalLink } from '../../../utils/external-link-validation';
@@ -63,6 +64,7 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
 
   public componentDidUpdate = (prevProps: ISampleQueriesProps) => {
     if (prevProps.samples.queries !== this.props.samples.queries) {
+      this.props.actions!.fetchScopes();
       this.setState({ sampleQueries: this.props.samples.queries });
     }
   };
@@ -291,6 +293,7 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
         }
       }
       actions.setSampleQuery(sampleQuery);
+      actions.fetchScopes();
     }
   };
 
@@ -483,6 +486,7 @@ function mapDispatchToProps(dispatch: Dispatch): object {
   return {
     actions: bindActionCreators(
       {
+        fetchScopes,
         ...queryActionCreators,
         ...queryInputActionCreators,
         ...samplesActionCreators,

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -359,5 +359,7 @@
   "As user": "(as user)",
   "As Teams app": "(as Teams app)",
   "Use Explorer as sample Teams application": "Use Explorer as sample Teams application",
-  "Use Explorer as logged-in user": "Use Explorer as logged-in user"
+  "Use Explorer as logged-in user": "Use Explorer as logged-in user",
+  "delegated user mode": "This query requires permissions that can only be found in delegated user mode. Switch to delegated user mode in the top left three dots.",
+  "application mode": "This query requires permissions that can only be found application mode. Switch to application mode in the top left three dots."
 }

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -357,5 +357,7 @@
   "Click here to follow the link": "Click here to follow the link",
   "Signing you out...": "Signing you out...",
   "As user": "(as user)",
-  "As Teams app": "(as Teams app)"
+  "As Teams app": "(as Teams app)",
+  "delegated user mode": "This query requires permissions that can only be found in delegated user mode. Switch to delegated user mode in the top left hamburger menu.",
+  "application mode": "This query requires permissions that can only be found application mode. Switch to application mode in the top left hamburger menu."
 }

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -360,6 +360,6 @@
   "As Teams app": "(as Teams app)",
   "Use Explorer as sample Teams application": "Use Explorer as sample Teams application",
   "Use Explorer as logged-in user": "Use Explorer as logged-in user",
-  "delegated user mode": "This query requires permissions that can only be found in delegated user mode. Switch to delegated user mode in the top left three dots.",
+  "delegated user mode": "This query requires permissions that can only be found in delegated user mode. Shown below is the response for the delegated user. Switch to delegated user mode in the top left three dots.",
   "application mode": "This query requires permissions that can only be found application mode. Switch to application mode in the top left three dots."
 }

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -358,6 +358,6 @@
   "Signing you out...": "Signing you out...",
   "As user": "(as user)",
   "As Teams app": "(as Teams app)",
-  "delegated user mode": "This query requires permissions that can only be found in delegated user mode. Switch to delegated user mode in the top left hamburger menu.",
-  "application mode": "This query requires permissions that can only be found application mode. Switch to application mode in the top left hamburger menu."
+  "delegated user mode": "This query requires permissions that can only be found in delegated user mode. Shown below is the response for the delegated user. Switch to delegated user mode in the top left three dots.",
+  "application mode": "This query requires permissions that can only be found application mode. Switch to application mode in the top left three dots."
 }

--- a/src/types/query-runner.ts
+++ b/src/types/query-runner.ts
@@ -100,6 +100,7 @@ export interface ISampleQueriesProps {
     setSampleQuery: Function;
     fetchSamples: Function;
     setQueryResponseStatus: Function;
+    fetchScopes: Function;
   };
   intl: {
     message: object;


### PR DESCRIPTION
## Overview

If you want to try out a query but you're in the wrong mode, this error will tell you to switch to another mode. 

### Demo

![image](https://user-images.githubusercontent.com/55033656/124299080-df2b0e80-db11-11eb-95f9-840f102b58ee.png)
![error-message](https://user-images.githubusercontent.com/55033656/124331554-4792e380-db44-11eb-88f4-0b1064952675.gif)
![error](https://user-images.githubusercontent.com/55033656/124331559-48c41080-db44-11eb-9201-b21549a10155.gif)

### Notes

The branch I based off of is when interns/feature/switch-permissions still had the cat button.
The Status messages are usually being generated based on the response from query. For this PR, the Status messages are being generated based on the permissions. 

## Testing Instructions

* pull the branch
* run the code