### PR TITLE
AB#38301 Make panel permissions switch between delegated and RSC

### DIFF
--- a/src/app/services/actions/permission-mode-action-creator.ts
+++ b/src/app/services/actions/permission-mode-action-creator.ts
@@ -7,5 +7,5 @@ export function changeMode(newPerm: boolean): IAction {
     return {
         type: CHANGE_PERMISSIONS_MODE_SUCCESS,
         response: newPerm,
-    };
+    };;
 }

--- a/src/app/services/actions/permission-mode-action-creator.ts
+++ b/src/app/services/actions/permission-mode-action-creator.ts
@@ -7,5 +7,5 @@ export function changeMode(newPerm: boolean): IAction {
     return {
         type: CHANGE_PERMISSIONS_MODE_SUCCESS,
         response: newPerm,
-    };;
+    };
 }

--- a/src/app/services/actions/permissions-action-creator.ts
+++ b/src/app/services/actions/permissions-action-creator.ts
@@ -66,6 +66,10 @@ export function fetchScopes(): Function {
         permissionsUrl = `${permissionsUrl}${query ? '&' : '?'}${devxApi.parameters}`;
       }
 
+      if (permissionsPanelOpen) {
+        permissionsUrl = `${devxApi.baseUrl}/permissions?scopeType=${scope}`;
+      }
+
       const headers = {
         'Content-Type': 'application/json',
         'Accept-Language': geLocale,


### PR DESCRIPTION
## Overview
WILL MERGE INTO `interns/dev` once `interns/feature/switch-permissions` is merged into interns/dev. 

Displays DelegatedWork permissions while in user mode and displays Application permissions while in app mode. The API currently doesn't return RSC.

### Demo

Application mode (scopes is 214)
![image](https://user-images.githubusercontent.com/55033656/124337585-30f68780-db58-11eb-9542-c3cc8fdb771f.png)

User mode (scopes is 290)
![image](https://user-images.githubusercontent.com/55033656/124337609-48ce0b80-db58-11eb-9146-20c4822ff649.png)

### Notes

The API doesn't return any RSC permissions. I could pull them from the README.md like I did for the Teams app.

## Testing Instructions

* Pull the branch and run: `npm install && npm start`