### PR TITLE
AB#38296 Add telemetry for added app to user mode functionality button 

### DIFF
--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -86,8 +86,8 @@ function Settings(props: ISettingsProps) {
       menuItems.push(
         {
           key: 'switch-user-app-mode',
-          text: translateMessage(permissionModeType 
-            ? "Use Explorer as sample Teams application" 
+          text: translateMessage(permissionModeType
+            ? "Use Explorer as sample Teams application"
             : "Use Explorer as logged-in user"),
           iconProps: {
             iconName: permissionModeType ? "TeamsLogo" : "Contact",
@@ -127,14 +127,22 @@ function Settings(props: ISettingsProps) {
   };
 
   const handleChangeMode = (permissionModeType: PERMISSION_MODE_TYPE) => {
+    let newPermissionModeType;
     switch (permissionModeType) {
       case PERMISSION_MODE_TYPE.User:
+        newPermissionModeType = PERMISSION_MODE_TYPE.TeamsApp;
         dispatch(changeMode(PERMISSION_MODE_TYPE.TeamsApp));
         break;
       case PERMISSION_MODE_TYPE.TeamsApp:
+        newPermissionModeType = PERMISSION_MODE_TYPE.User;
         dispatch(changeMode(PERMISSION_MODE_TYPE.User));
         break;
     }
+    telemetry.trackEvent(
+      eventTypes.BUTTON_CLICK_EVENT, {
+      ComponentName: componentNames.CHANGE_PERMISSIONS_MODE_BUTTON,
+      PermissionMode: newPermissionModeType
+    });
   };
 
   const handleSignOut = () => {

--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -30,6 +30,7 @@ import { togglePermissionsPanel } from '../../services/actions/permissions-panel
 import { changeMode } from '../../services/actions/permission-mode-action-creator';
 import { changeTheme } from '../../services/actions/theme-action-creator';
 import { Permission } from '../query-runner/request/permissions';
+import { DISPLAY_APPLICATION_PERMISSIONS } from '../../services/graph-constants';
 
 
 function Settings(props: ISettingsProps) {
@@ -124,6 +125,11 @@ function Settings(props: ISettingsProps) {
 
   const handleChangeMode = (permissionModeType: boolean) => {
     dispatch(changeMode(!permissionModeType));
+    telemetry.trackEvent(
+      eventTypes.BUTTON_CLICK_EVENT, {
+      ComponentName: componentNames.CHANGE_PERMISSIONS_MODE_BUTTON,
+      PermissionMode: !permissionModeType
+    });
   };
 
   const handleSignOut = () => {

--- a/src/telemetry/component-names.ts
+++ b/src/telemetry/component-names.ts
@@ -14,6 +14,7 @@ export const CODE_SNIPPETS_COPY_BUTTON = 'Code snippets copy button';
 export const VIEW_ALL_PERMISSIONS_BUTTON = 'View all permissions button';
 export const EXPORT_HISTORY_ITEM_BUTTON = 'Export history item button';
 export const DELETE_HISTORY_ITEM_BUTTON = 'Delete history item button';
+export const CHANGE_PERMISSIONS_MODE_BUTTON = 'Change to permissions mode button';
 
 // List items
 export const HISTORY_LIST_ITEM = 'History list item';


### PR DESCRIPTION
## Overview

We want to be able to track how many times a user tries out this feature -> add telemetry.

### Notes

Extended already existing telemetry to track our new user / app mode button.

## Testing Instructions

* Not sure if this can be tested? Maybe looking at the telemetry tracker?