### PR TITLE
AB#38717 Interns/jerryxihe/38717 access token error in app mode

### DIFF
--- a/src/app/views/query-runner/request/auth/Auth.tsx
+++ b/src/app/views/query-runner/request/auth/Auth.tsx
@@ -50,6 +50,16 @@ export function Auth(props: any) {
     </MessageBar>;
   }
 
+  let accessTokenComponent;
+  if (permissionModeType === PERMISSION_MODE_TYPE.User) {
+    accessTokenComponent = <Label className={classes.accessToken}>{accessToken}</Label>;
+  } else {
+    accessTokenComponent =
+      <Label className={classes.appModeAccessTokenError}>
+        <FormattedMessage id="App mode access token error" />
+      </Label>
+  }
+
   return (<div className={classes.auth} style={{ height: requestHeight }}>
     {!loading ?
       <div>
@@ -62,7 +72,7 @@ export function Auth(props: any) {
             href={`https://jwt.ms#access_token=${accessToken}`}
             target='_blank' />
         </div>
-        <Label className={classes.accessToken} >{permissionModeType === PERMISSION_MODE_TYPE.User ? accessToken : "Access token is unviewable in application mode for security reasons."}</Label>
+        {accessTokenComponent}
       </div>
       :
       <Label className={classes.emptyStateLabel}>

--- a/src/app/views/query-runner/request/auth/Auth.tsx
+++ b/src/app/views/query-runner/request/auth/Auth.tsx
@@ -12,9 +12,10 @@ import { classNames } from '../../../classnames';
 import { genericCopy } from '../../../common/copy';
 import { convertVhToPx } from '../../../common/dimensions-adjustment';
 import { authStyles } from './Auth.styles';
+import { PERMISSION_MODE_TYPE } from '../../../../../app/services/graph-constants';
 
 export function Auth(props: any) {
-  const { authToken, dimensions: { request: { height } } } = useSelector((state: IRootState) => state);
+  const { authToken, dimensions: { request: { height } }, permissionModeType } = useSelector((state: IRootState) => state);
   const requestHeight = convertVhToPx(height, 60);
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -61,7 +62,7 @@ export function Auth(props: any) {
             href={`https://jwt.ms#access_token=${accessToken}`}
             target='_blank' />
         </div>
-        <Label className={classes.accessToken} >{accessToken}</Label>
+        <Label className={classes.accessToken} >{permissionModeType === PERMISSION_MODE_TYPE.User ? accessToken : "Access token is unviewable in application mode for security reasons."}</Label>
       </div>
       :
       <Label className={classes.emptyStateLabel}>

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -359,5 +359,6 @@
   "As user": "(as user)",
   "As Teams app": "(as Teams app)",
   "Use Explorer as sample Teams application": "Use Explorer as sample Teams application",
-  "Use Explorer as logged-in user": "Use Explorer as logged-in user"
+  "Use Explorer as logged-in user": "Use Explorer as logged-in user",
+  "App mode access token error": "Access token is unviewable in application mode for security reasons."
 }

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -1,4 +1,5 @@
 import { ITheme } from '@uifabric/styling';
+import { PERMISSION_MODE_TYPE } from '../app/services/graph-constants';
 import { IDimensions } from './dimensions';
 import { IQuery } from './query-runner';
 
@@ -24,7 +25,7 @@ export interface IPermissionProps {
     fetchScopes: Function;
     consentToScopes: Function;
   };
-  permissionModeType: boolean;
+  permissionModeType: PERMISSION_MODE_TYPE;
 }
 
 export interface IPermissionState {

--- a/src/types/query-runner.ts
+++ b/src/types/query-runner.ts
@@ -1,4 +1,5 @@
 import { ITheme } from '@uifabric/styling';
+import { PERMISSION_MODE_TYPE } from '../app/services/graph-constants';
 import { Mode } from './enums';
 
 export interface IQueryRunnerState {
@@ -29,7 +30,7 @@ export interface IQueryRunnerProps {
     setSampleQuery: Function;
     setQueryResponseStatus: Function;
   };
-  permissionModeType: boolean;
+  permissionModeType: PERMISSION_MODE_TYPE;
 }
 
 export interface IQueryInputProps {


### PR DESCRIPTION
ADO Board Link: [Task #38717](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_sprints/taskboard/GI21%20-%20Graph%20Explorer/Intern%20GitHub/Y21-S/04?workitem=38717)

## Overview

* We cannot expose the app token when in app mode, so we will display an error message instead stating that the token cannot be shown for security reasons.
* Fixed two places where `permissionModeType` was still a boolean, not an enum (changed in https://github.com/LokiLabs/microsoft-graph-explorer-v4/pull/23).

### Demo

See `Testing Instructions`.

### Notes

## Testing Instructions

* Check out this branch
* Run `nvm use 14.0.0`
* Run `npm install && npm start`

**Demo steps:**

Step 1
* Log into Graph Explorer. You should see the words `(as user)` appear next to your name.
* Click the `Access token` tab, as seen below.
* You should see an access token (a super long string of random characters).

![image](https://user-images.githubusercontent.com/46834951/124819843-0165c780-df2a-11eb-98fd-a66bcdcca41e.png)

Step 2
* Click the `...` button in your Profile section. You should see 6 options, with `Use Explorer as sample Teams application` third from the bottom, as seen below. Click that option.

![image](https://user-images.githubusercontent.com/46834951/124820057-3f62eb80-df2a-11eb-9594-3e1c8bc87bc1.png)

Step 3
* The words `(as Teams app)` should now appear next to your name.
* You should now see `Access token is unviewable in application mode for security reasons.` in the `Access token` tab, instead of an access token.

![image](https://user-images.githubusercontent.com/46834951/124820820-3292c780-df2b-11eb-893b-b1ba4ea91e86.png)

Step 4
* Click the `...` button again in your Profile section. You should still see 6 options, but the third option from the button should now say `Use Explorer as logged-in user`. Click that option.

![image](https://user-images.githubusercontent.com/46834951/124820431-b5675280-df2a-11eb-923d-7bf1e366f243.png)

Step 5
* You should now be in the same state as Step 1.


