### PR TITLE
38277 Query Input Wrapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@azure/msal-browser": "2.12.0",
     "@babel/core": "7.12.13",
     "@babel/eslint-parser": "7.12.13",
+    "@fluentui/react": "^8.22.2",
     "@microsoft/applicationinsights-react-js": "2.3.1",
     "@microsoft/applicationinsights-web": "2.3.1",
     "@microsoft/microsoft-graph-client": "2.1.0",

--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -60,6 +60,9 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
     this.props.contentChanged(userInput);
   };
 
+  // This method is bugged because it fails to grab the correct font from the div?
+  // I am not actually sure how to make a better isOverflowing method, so this is
+  // primarily a proof of concept.
   public isOverflowing = (input: string) => {
 
     function getTextWidth(text: string) {
@@ -426,7 +429,6 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
             resizable={false}
             type='text'
             autoComplete='off'
-            // eslint-disable-next-line react/jsx-no-bind
             onChange={this.onChange}
             onBlur={this.updateUrlContent}
             onKeyDown={this.onKeyDown}

--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -74,8 +74,7 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
       return context.measureText(text).width + 5;
     }
 
-    return this.element !== null
-      && this.element !== undefined
+    return !!this.element
       && getTextWidth(input) > this.element.scrollWidth;
 
   }
@@ -436,6 +435,7 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
             onRenderSuffix={(this.renderSuffix()) ? this.renderSuffix : undefined}
             ariaLabel={translateMessage('Query Sample Input')}
             role='textbox'
+            errorMessage={!queryUrl ? translateMessage('Missing url') : ''}
           />
         </div>
         {showSuggestions && userInput && filteredSuggestions.length > 0 &&

--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -24,6 +24,7 @@ import SuggestionsList from './SuggestionsList';
 
 class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
   private autoCompleteRef: React.RefObject<ITextField>;
+  private element: HTMLDivElement | null | undefined;
 
   constructor(props: IAutoCompleteProps) {
     super(props);
@@ -59,6 +60,25 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
     this.props.contentChanged(userInput);
   };
 
+  public isOverflowing = (input: string) => {
+
+    function getTextWidth(text: string) {
+      const canvas = document.createElement('canvas');
+      const context = canvas.getContext('2d');
+    
+      if (context === null) return 0;
+
+      context.font = getComputedStyle(document.body).font;
+      console.log(context.font);
+      return context.measureText(text).width + 5;
+    }
+
+    return this.element !== null
+      && this.element !== undefined
+      && getTextWidth(input) > this.element.scrollWidth;
+
+  }
+
   public onChange = (e: any) => {
     const { suggestions, showSuggestions, userInput: previousUserInput, compare } = this.state;
     const userInput = e.target.value;
@@ -66,7 +86,7 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
     this.setState({
       userInput,
       queryUrl: userInput,
-      multiline: (userInput.length > 50)
+      multiline: this.isOverflowing(userInput)
     });
 
     if (showSuggestions && suggestions.length) {
@@ -254,7 +274,8 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
       if (newUrl !== this.state.queryUrl) {
         this.setState({
           queryUrl: newUrl,
-          userInput: newUrl
+          userInput: newUrl,
+          multiline: this.isOverflowing(newUrl)
         });
       }
     }
@@ -397,23 +418,25 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
 
     return (
       <div onBlur={this.closeSuggestionDialog}>
-        <TextField
-          className={autoInput}
-          multiline={multiline}
-          autoAdjustHeight 
-          resizable={false}
-          type='text'
-          autoComplete='off'
-          // eslint-disable-next-line react/jsx-no-bind
-          onChange={this.onChange}
-          onBlur={this.updateUrlContent}
-          onKeyDown={this.onKeyDown}
-          value={queryUrl}
-          componentRef={this.autoCompleteRef}
-          onRenderSuffix={(this.renderSuffix()) ? this.renderSuffix : undefined}
-          ariaLabel={translateMessage('Query Sample Input')}
-          role='textbox'
-        />
+        <div ref={(el) => {this.element = el}}>
+          <TextField 
+            className={autoInput}
+            multiline={multiline}
+            autoAdjustHeight 
+            resizable={false}
+            type='text'
+            autoComplete='off'
+            // eslint-disable-next-line react/jsx-no-bind
+            onChange={this.onChange}
+            onBlur={this.updateUrlContent}
+            onKeyDown={this.onKeyDown}
+            value={queryUrl}
+            componentRef={this.autoCompleteRef}
+            onRenderSuffix={(this.renderSuffix()) ? this.renderSuffix : undefined}
+            ariaLabel={translateMessage('Query Sample Input')}
+            role='textbox'
+          />
+        </div>
         {showSuggestions && userInput && filteredSuggestions.length > 0 &&
           <SuggestionsList
             filteredSuggestions={filteredSuggestions}

--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -66,10 +66,11 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
       const canvas = document.createElement('canvas');
       const context = canvas.getContext('2d');
     
-      if (context === null) return 0;
+      if (context === null) {
+        return 0;
+      }
 
       context.font = getComputedStyle(document.body).font;
-      console.log(context.font);
       return context.measureText(text).width + 5;
     }
 

--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -2,8 +2,6 @@ import { getId, getTheme, Icon, ITextField, KeyCodes, Spinner, TooltipHost } fro
 import { ITooltipHostStyles } from 'office-ui-fabric-react/lib/components/Tooltip/TooltipHost.types';
 import React, { Component } from 'react';
 import { TextField } from '@fluentui/react/lib/TextField';
-import { useBoolean } from '@fluentui/react-hooks';
-import { Stack, IStackProps, IStackStyles } from '@fluentui/react/lib/Stack';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
@@ -26,13 +24,11 @@ import SuggestionsList from './SuggestionsList';
 
 class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
   private autoCompleteRef: React.RefObject<ITextField>;
-  private multiline: any;
 
   constructor(props: IAutoCompleteProps) {
     super(props);
 
     this.autoCompleteRef = React.createRef();
-    this.multiline = false;
 
     this.state = {
       activeSuggestion: 0,
@@ -65,11 +61,6 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
   public onChange = (e: any) => {
     const { suggestions, showSuggestions, userInput: previousUserInput, compare } = this.state;
     const userInput = e.target.value;
-
-    const newMultiline = userInput.length > 50;
-    if (newMultiline !== this.multiline) {
-      this.multiline = !this.multiline;
-    }
 
     this.setState({
       userInput,
@@ -388,13 +379,6 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
 
   public render() {
 
-    const stackStyles: Partial<IStackStyles> = { root: { width: 650 } };
-    const stackTokens = { childrenGap: 50 };
-    const columnProps: Partial<IStackProps> = {
-      tokens: { childrenGap: 15 },
-      styles: { root: { width: 300 } },
-    };
-
     const {
       activeSuggestion,
       filteredSuggestions,
@@ -410,25 +394,23 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
 
     return (
       <div onBlur={this.closeSuggestionDialog}>
-        <Stack horizontal tokens={stackTokens} styles={stackStyles}>
-          <Stack {...columnProps}>
-            <TextField
-              className={autoInput}
-              type='text'
-              autoComplete='off'
-              multiline={this.multiline}
-              // eslint-disable-next-line react/jsx-no-bind
-              onChange={this.onChange}
-              onBlur={this.updateUrlContent}
-              onKeyDown={this.onKeyDown}
-              value={queryUrl}
-              componentRef={this.autoCompleteRef}
-              onRenderSuffix={(this.renderSuffix()) ? this.renderSuffix : undefined}
-              ariaLabel={translateMessage('Query Sample Input')}
-              role='textbox'
-            />
-          </Stack>
-        </Stack>
+        <TextField
+          className={autoInput}
+          multiline 
+          autoAdjustHeight 
+          resizable={false}
+          type='text'
+          autoComplete='off'
+          // eslint-disable-next-line react/jsx-no-bind
+          onChange={this.onChange}
+          onBlur={this.updateUrlContent}
+          onKeyDown={this.onKeyDown}
+          value={queryUrl}
+          componentRef={this.autoCompleteRef}
+          onRenderSuffix={(this.renderSuffix()) ? this.renderSuffix : undefined}
+          ariaLabel={translateMessage('Query Sample Input')}
+          role='textbox'
+        />
         {showSuggestions && userInput && filteredSuggestions.length > 0 &&
           <SuggestionsList
             filteredSuggestions={filteredSuggestions}

--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -1,6 +1,9 @@
-import { getId, getTheme, Icon, ITextField, KeyCodes, Spinner, TextField, TooltipHost } from 'office-ui-fabric-react';
+import { getId, getTheme, Icon, ITextField, KeyCodes, Spinner, TooltipHost } from 'office-ui-fabric-react';
 import { ITooltipHostStyles } from 'office-ui-fabric-react/lib/components/Tooltip/TooltipHost.types';
 import React, { Component } from 'react';
+import { TextField } from '@fluentui/react/lib/TextField';
+import { useBoolean } from '@fluentui/react-hooks';
+import { Stack, IStackProps, IStackStyles } from '@fluentui/react/lib/Stack';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 
@@ -23,11 +26,13 @@ import SuggestionsList from './SuggestionsList';
 
 class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
   private autoCompleteRef: React.RefObject<ITextField>;
+  private multiline: any;
 
   constructor(props: IAutoCompleteProps) {
     super(props);
 
     this.autoCompleteRef = React.createRef();
+    this.multiline = false;
 
     this.state = {
       activeSuggestion: 0,
@@ -60,6 +65,11 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
   public onChange = (e: any) => {
     const { suggestions, showSuggestions, userInput: previousUserInput, compare } = this.state;
     const userInput = e.target.value;
+
+    const newMultiline = userInput.length > 50;
+    if (newMultiline !== this.multiline) {
+      this.multiline = !this.multiline;
+    }
 
     this.setState({
       userInput,
@@ -377,6 +387,14 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
   }
 
   public render() {
+
+    const stackStyles: Partial<IStackStyles> = { root: { width: 650 } };
+    const stackTokens = { childrenGap: 50 };
+    const columnProps: Partial<IStackProps> = {
+      tokens: { childrenGap: 15 },
+      styles: { root: { width: 300 } },
+    };
+
     const {
       activeSuggestion,
       filteredSuggestions,
@@ -392,20 +410,25 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
 
     return (
       <div onBlur={this.closeSuggestionDialog}>
-        <TextField
-          className={autoInput}
-          type='text'
-          autoComplete='off'
-          onChange={this.onChange}
-          onBlur={this.updateUrlContent}
-          onKeyDown={this.onKeyDown}
-          value={queryUrl}
-          componentRef={this.autoCompleteRef}
-          onRenderSuffix={(this.renderSuffix()) ? this.renderSuffix : undefined}
-          ariaLabel={translateMessage('Query Sample Input')}
-          role='textbox'
-          errorMessage={!queryUrl ? translateMessage('Missing url') : ''}
-        />
+        <Stack horizontal tokens={stackTokens} styles={stackStyles}>
+          <Stack {...columnProps}>
+            <TextField
+              className={autoInput}
+              type='text'
+              autoComplete='off'
+              multiline={this.multiline}
+              // eslint-disable-next-line react/jsx-no-bind
+              onChange={this.onChange}
+              onBlur={this.updateUrlContent}
+              onKeyDown={this.onKeyDown}
+              value={queryUrl}
+              componentRef={this.autoCompleteRef}
+              onRenderSuffix={(this.renderSuffix()) ? this.renderSuffix : undefined}
+              ariaLabel={translateMessage('Query Sample Input')}
+              role='textbox'
+            />
+          </Stack>
+        </Stack>
         {showSuggestions && userInput && filteredSuggestions.length > 0 &&
           <SuggestionsList
             filteredSuggestions={filteredSuggestions}

--- a/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
+++ b/src/app/views/query-runner/query-input/auto-complete/AutoComplete.tsx
@@ -37,7 +37,8 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
       showSuggestions: false,
       userInput: this.props.sampleQuery.sampleUrl,
       queryUrl: this.props.sampleQuery.sampleUrl,
-      compare: ''
+      compare: '',
+      multiline: false
     };
   }
 
@@ -64,7 +65,8 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
 
     this.setState({
       userInput,
-      queryUrl: userInput
+      queryUrl: userInput,
+      multiline: (userInput.length > 50)
     });
 
     if (showSuggestions && suggestions.length) {
@@ -384,7 +386,8 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
       filteredSuggestions,
       showSuggestions,
       userInput,
-      queryUrl
+      queryUrl,
+      multiline
     } = this.state;
 
     const currentTheme = getTheme();
@@ -396,7 +399,7 @@ class AutoComplete extends Component<IAutoCompleteProps, IAutoCompleteState> {
       <div onBlur={this.closeSuggestionDialog}>
         <TextField
           className={autoInput}
-          multiline 
+          multiline={multiline}
           autoAdjustHeight 
           resizable={false}
           type='text'

--- a/src/app/views/query-runner/query-input/auto-complete/auto-complete.styles.ts
+++ b/src/app/views/query-runner/query-input/auto-complete/auto-complete.styles.ts
@@ -61,6 +61,7 @@ export const autoCompleteStyles = (theme: ITheme) => {
       borderWidth: '1px',
       borderStyle: 'solid',
       overflow: 'hidden',
+      wordWrap: "normal",
       backgroundColor: theme.palette.neutralLight
     },
     suggestionTitle: {

--- a/src/types/auto-complete.ts
+++ b/src/types/auto-complete.ts
@@ -26,6 +26,7 @@ export interface IAutoCompleteState {
   userInput: string;
   compare: string;
   queryUrl: string;
+  multiline: boolean;
 }
 
 export interface ISuggestionsList {


### PR DESCRIPTION
The text box for the query input currently does not wrap the text, creating an annoying issue of large queries being cut off.

This PR intends to fix this problem by making the height of the textbox adjustable based on the input.
AD#38277

Notably, this PR is a bit hacky, as I didn't know a few things. If I could receive input on the following, it would help the PR significantly, I think:

- No idea how to set a starting height for multiline autoAdjustHeight FluentUI TextFields; As far as I could tell, ​autoAdjustHeight​ forces the minimum height to 60px and idk where to modify that
- The switch from single line to multi line is to fix the above; However, the detection for overflow is most definitely buggy. It works, but it is off by a little bit depending on which letters you used to fill the box, so I imagine it is a font issue; I am curious if there is a better way to detect overflow in FluentUI?

This PR also solves the following issue: https://github.com/microsoftgraph/microsoft-graph-explorer-v4/issues/613

PR on main GE: https://github.com/microsoftgraph/microsoft-graph-explorer-v4/pull/1020

[AD#38277](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_sprints/taskboard/GI21%20-%20Graph%20Explorer/Intern%20GitHub/Y21-S/06?workitem=38277)