### PR TITLE
AB#38301 remove select perms panel when in app mode

### DIFF
--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -82,25 +82,28 @@ function Settings(props: ISettingsProps) {
       }
     ];
 
+    if (permissionModeType === PERMISSION_MODE_TYPE.User) {
+      menuItems.push({
+        key: 'view-all-permissions',
+        text: translateMessage('view all permissions'),
+        iconProps: {
+          iconName: 'AzureKeyVault',
+        },
+        onClick: () => changePanelState(),
+      });
+    }
+
     if (authenticated) {
       menuItems.push(
         {
           key: 'switch-user-app-mode',
-          text: translateMessage(permissionModeType 
-            ? "Use Explorer as sample Teams application" 
+          text: translateMessage(permissionModeType
+            ? "Use Explorer as sample Teams application"
             : "Use Explorer as logged-in user"),
           iconProps: {
             iconName: permissionModeType ? "TeamsLogo" : "Contact",
           },
           onClick: () => handleChangeMode(permissionModeType),
-        },
-        {
-          key: 'view-all-permissions',
-          text: translateMessage('view all permissions'),
-          iconProps: {
-            iconName: 'AzureKeyVault',
-          },
-          onClick: () => changePanelState(),
         },
         {
           key: 'sign-out',


### PR DESCRIPTION
## Overview

Currently the three dots menu shows "Select Permissions" in app mode but we currently can't consent to RSC or app permssions in the Graph Explorer. This PR removes the choice from the menu. 

### Demo

User mode
![image](https://user-images.githubusercontent.com/55033656/125331468-df3ec180-e2fc-11eb-8e03-0d000a91082f.png)

Teams app mode
![image](https://user-images.githubusercontent.com/55033656/125331495-e6fe6600-e2fc-11eb-83b5-e8450179c962.png)