### PR TITLE
AB#38879 Interns/jerryxihe/38879 remove access token buttons in app mode

### DIFF
--- a/src/app/views/query-runner/request/auth/Auth.tsx
+++ b/src/app/views/query-runner/request/auth/Auth.tsx
@@ -65,12 +65,16 @@ export function Auth(props: any) {
       <div>
         <div className={classes.accessTokenContainer}>
           <Label className={classes.accessTokenLabel}><FormattedMessage id='Access Token' /></Label>
-          <IconButton onClick={handleCopy} iconProps={copyIcon} title='Copy' ariaLabel='Copy' />
-          <IconButton iconProps={tokenDetailsIcon}
-            title={translateMessage('Get token details (Powered by jwt.ms)')}
-            ariaLabel={translateMessage('Get token details (Powered by jwt.ms)')}
-            href={`https://jwt.ms#access_token=${accessToken}`}
-            target='_blank' />
+          {(permissionModeType === PERMISSION_MODE_TYPE.User) &&
+            <IconButton onClick={handleCopy} iconProps={copyIcon} title='Copy' ariaLabel='Copy' />
+          }
+          {(permissionModeType === PERMISSION_MODE_TYPE.User) &&
+            <IconButton iconProps={tokenDetailsIcon}
+              title={translateMessage('Get token details (Powered by jwt.ms)')}
+              ariaLabel={translateMessage('Get token details (Powered by jwt.ms)')}
+              href={`https://jwt.ms#access_token=${accessToken}`}
+              target='_blank' />
+          }
         </div>
         {accessTokenComponent}
       </div>

--- a/src/app/views/query-runner/request/auth/Auth.tsx
+++ b/src/app/views/query-runner/request/auth/Auth.tsx
@@ -66,14 +66,14 @@ export function Auth(props: any) {
         <div className={classes.accessTokenContainer}>
           <Label className={classes.accessTokenLabel}><FormattedMessage id='Access Token' /></Label>
           {(permissionModeType === PERMISSION_MODE_TYPE.User) &&
-            <IconButton onClick={handleCopy} iconProps={copyIcon} title='Copy' ariaLabel='Copy' />
-          }
-          {(permissionModeType === PERMISSION_MODE_TYPE.User) &&
-            <IconButton iconProps={tokenDetailsIcon}
-              title={translateMessage('Get token details (Powered by jwt.ms)')}
-              ariaLabel={translateMessage('Get token details (Powered by jwt.ms)')}
-              href={`https://jwt.ms#access_token=${accessToken}`}
-              target='_blank' />
+            <div>
+              <IconButton onClick={handleCopy} iconProps={copyIcon} title='Copy' ariaLabel='Copy' />
+              <IconButton iconProps={tokenDetailsIcon}
+                title={translateMessage('Get token details (Powered by jwt.ms)')}
+                ariaLabel={translateMessage('Get token details (Powered by jwt.ms)')}
+                href={`https://jwt.ms#access_token=${accessToken}`}
+                target='_blank' />
+            </div>
           }
         </div>
         {accessTokenComponent}

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -366,5 +366,5 @@
   "Learn more about": "Learn more about",
   "resource specific consent": "resource specific consent",
   "Graph Explorer Sample App": "Graph Explorer Sample App",
-  "App mode access token error": "Access token is unviewable in application mode for security reasons."
+  "App mode access token error": "Access token is hidden in application mode for security purposes."
 }


### PR DESCRIPTION
ADO Board Link: [Task #38879](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_workitems/edit/38879)

## Overview

* We needed to remove the `Copy` and `Get token details` buttons on the `Access Token` tab when in app mode.

### Demo

See `Testing Instructions`.

### Notes

## Testing Instructions

* Check out this branch.
* Run `nvm use --lts`
* Run `npm install && npm start`

**Demo steps:**

Step 1
* Log into Graph Explorer.

Step 2
* Click the `Access Token` tab. You should see the `Copy` and `Get token details` buttons right above the token string and to the left of the text `Access Token`, as shown below:

![image](https://user-images.githubusercontent.com/46834951/125496736-6a578f30-c6b8-4b52-9914-558828020693.png)

Step 3
* Click the `...` menu in the Profile section. Click `Use Explorer as sample Teams application`. Close the popup.

Step 4
* The `Copy` and `Get token details` buttons should now be gone:

![image](https://user-images.githubusercontent.com/46834951/125496869-d09b8a0a-c22a-4d20-90d6-a5616fee7413.png)
