### PR TITLE
Sample Query Sandbox IDs

### DIFF
--- a/src/app/views/sidebar/sample-queries/tokens.ts
+++ b/src/app/views/sidebar/sample-queries/tokens.ts
@@ -19,6 +19,10 @@ export function getTokens(user?: any) {
 
   const tokens: IToken[] = [
     {
+      placeholder: 'chat-id',
+      demoTenantValue: '19:2a395c1dfe36431fb6e4cd5b225c17ee@thread.v2',
+    },
+    {
       placeholder: 'group-id',
       demoTenantValue: '02bd9fd6-8f93-4758-87c3-1fb73740a315',
     },
@@ -101,6 +105,10 @@ export function getTokens(user?: any) {
     {
       placeholder: 'user-id',
       demoTenantValue: 'd4957c9d-869e-4364-830c-d0c95be72738',
+    },
+    {
+      placeholder: 'membership-id',
+      demoTenantValue: 'MCMjMCMjZGNkMjE5ZGQtYmM2OC00YjliLWJmMGItNGEzM2E3OTZiZTM1IyMxOToyYTM5NWMxZGZlMzY0MzFmYjZlNGNkNWIyMjVjMTdlZUB0aHJlYWQudjIjIzQ4ZDMxODg3LTVmYWQtNGQ3My1hOWY1LTNjMzU2ZTY4YTAzOA==',
     },
     {
       placeholder: 'today',


### PR DESCRIPTION
These IDs will allow the following Sample Query PRs to merge:
https://github.com/LokiLabs/microsoft-graph-devx-content/pull/5
https://github.com/LokiLabs/microsoft-graph-devx-content/pull/8

I grabbed them via the sandbox mode (non-logged-in) with `GET https://graph.microsoft.com/beta/me/chats` (for `chat-id`) and then `GET https://graph.microsoft.com/beta/me/chats/{chat-id from above}/members` (for `membership-id`).

I think this should be good to merge as-is, but do let me know if there's anything I'm missing. I want to merge the PRs above by end of day since they've been held for a few weeks now, so sooner rather than later is ideal if possible! :3 


Edit:

I will likely end up merging PRs 5 and 8 into `interns/feature/new-sample-queries`, to which I can verify everything is in order and request a final quick review.