### PR TITLE
AB#39140 update RSC popup dialog to match GE experience and Fluent UI standards

### DIFF
--- a/src/app/services/graph-constants.ts
+++ b/src/app/services/graph-constants.ts
@@ -19,4 +19,4 @@ export const RSC_PERMISSIONS_ENDINGS = [".Group", ".Chat"];
 export const RSC_URL = "https://docs.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/resource-specific-consent";
 export const APP_IMAGE = "https://docs.microsoft.com/en-us/microsoftteams/platform/assets/icons/graph-icon-1.png";
 export const TEAMS_APP_ID = "46c88300-12bd-44cb-b3ba-734ed25fe1de";
-export const INSTALLED_APP_URL = "https://docs.microsoft.com/en-us/graph/api/userteamwork-list-installedapps?view=graph-rest-1.0&tabs=http";
+export const TEAMS_APP_URL = "https://www.bing.com/?form=000010";

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -1,6 +1,6 @@
 import {
   Announced,
-  IStackTokens, ITheme, styled, Dialog
+  IStackTokens, ITheme, styled, Dialog, DialogFooter, PrimaryButton, DefaultButton
 } from 'office-ui-fabric-react';
 import React, { Component } from 'react';
 import { InjectedIntl, injectIntl } from 'react-intl';
@@ -24,7 +24,7 @@ import { clearTermsOfUse } from '../services/actions/terms-of-use-action-creator
 import { changeThemeSuccess } from '../services/actions/theme-action-creator';
 import { toggleSidebar } from '../services/actions/toggle-sidebar-action-creator';
 import { changePopUp } from '../services/actions/permission-mode-action-creator';
-import { GRAPH_URL, PERMISSION_MODE_TYPE } from '../services/graph-constants';
+import { GRAPH_URL, PERMISSION_MODE_TYPE, RSC_URL, TEAMS_APP_URL } from '../services/graph-constants';
 import { parseSampleUrl } from '../utils/sample-url-generation';
 import { substituteTokens } from '../utils/token-helpers';
 import { translateMessage } from '../utils/translate-messages';
@@ -41,8 +41,7 @@ import { QueryRunner } from './query-runner';
 import { parse } from './query-runner/util/iframe-message-parser';
 import { Settings } from './settings';
 import { Sidebar } from './sidebar/Sidebar';
-import { RSC_URL, INSTALLED_APP_URL } from '../services/graph-constants';
-import { responseAreaExpanded } from '../services/reducers/response-expanded-reducer';
+
 interface IAppProps {
   theme?: ITheme;
   styles?: object;
@@ -344,28 +343,22 @@ class App extends Component<IAppProps, IAppState> {
     if (mobileScreen) {
       sidebarWidth = layout = 'col-xs-12 col-sm-12';
     }
-    // eslint-disable-next-line react/jsx-no-target-blank
-    const teamsapp = <a href={"https://www.bing.com/?form=000010"} target="_blank">{translateMessage('Sample Explorer Teams app')}</a>;
-    //TODO: put in the url when we have this set up ADO #38728
-    // eslint-disable-next-line react/jsx-no-target-blank
-    const rsc = <a href={RSC_URL} target="_blank">{translateMessage('resource-specific consent')}</a>;
-    // eslint-disable-next-line react/jsx-no-target-blank
     return (
       // @ts-ignore
       <ThemeContext.Provider value={this.props.appTheme}>
-        {permissionModeType === PERMISSION_MODE_TYPE.TeamsApp && < Dialog
+        {permissionModeType === PERMISSION_MODE_TYPE.TeamsApp && <Dialog
           hidden={hideDialog}
           dialogContentProps={{
-            title: `${translateMessage('Install sample app')}`,
+            title: translateMessage('Install sample app'),
             showCloseButton: true,
+            subText: translateMessage('Resource-specific Consent popup'),
           }}
           onDismiss={this.toggleDialog}
         >
-          <div className={classes.docLink}>
-            <p> {translateMessage('Resource-specific Consent popup')} {teamsapp}. <br /> &nbsp;</p>
-            <p> {translateMessage('Learn more about')} {rsc}. <br /> &nbsp;</p>
-          </div>
-
+          <DialogFooter>
+            <PrimaryButton onClick={() => window.open(TEAMS_APP_URL, '_blank')} text={translateMessage('Install')} />
+            <DefaultButton onClick={() => window.open(RSC_URL, '_blank')} text={translateMessage('Learn more')} />
+          </DialogFooter>
         </Dialog>}
         <div className={`container-fluid ${classes.app}`}>
           <Announced message={!showSidebar ?

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -361,6 +361,7 @@
   "Use Graph Explorer as a signed in user": "Use Graph Explorer as a signed in user",
   "Resource-specific Consent popup": "To use resource-specific consent permissions, download the Sample Teams app for Graph Explorer. ​",
   "Install": "Install",
+  "Install sample app": "Install sample app",
   "Learn more": "Learn more",
   "App mode access token error": "Access token is hidden in application mode for security purposes."
 }

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -359,11 +359,8 @@
   "As user": "(signed in as user)",
   "Use Graph Explorer as a sample Teams application": "Use Graph Explorer as a sample Teams application",
   "Use Graph Explorer as a signed in user": "Use Graph Explorer as a signed in user",
-  "Resource-specific Consent popup": "To use resource-specific consent permissions, download​",
-  "Sample Teams app for Graph Explorer": "Sample Teams app for Graph Explorer",
-  "Install sample app": "Install sample app",
-  "Learn more about": "Learn more about",
-  "resource-specific consent": "resource-specific consent",
-  "Graph Explorer Sample App": "Graph Explorer Sample App",
+  "Resource-specific Consent popup": "To use resource-specific consent permissions, download the Sample Teams app for Graph Explorer. ​",
+  "Install": "Install",
+  "Learn more": "Learn more",
   "App mode access token error": "Access token is hidden in application mode for security purposes."
 }


### PR DESCRIPTION
## Overview

The Dialog that pops up when RSC mode toggled appears to be jarring with its current styling, especially in different themes. This PR updates the Dialog to follow Fluent UI standards. 


### Demo

![image](https://user-images.githubusercontent.com/47487758/126393729-213e3b7c-0a1a-415f-b863-6111c2bf2001.png)
![image](https://user-images.githubusercontent.com/47487758/126393665-ace02e57-6d49-4b81-bb22-9c6c89911630.png)


## Testing Instructions

* Checkout the branch, npm start and login as a user. 
* Click More options (three dots beside your user profile), select Use Graph Explorer as a Sample Teams application. 
* View the Dialog. 