### PR TITLE
AB#39173 add localStorage flag to hide RSC popup

### DIFF
--- a/src/app/services/actions/query-action-creators.ts
+++ b/src/app/services/actions/query-action-creators.ts
@@ -4,7 +4,7 @@ import { IHistoryItem } from '../../../types/history';
 import { IQuery } from '../../../types/query-runner';
 import { IStatus } from '../../../types/status';
 import { writeHistoryData } from '../../views/sidebar/history/history-utils';
-import { TEAMS_APP_ID } from '../graph-constants';
+import { TEAMS_APP_ID, RSC_HIDE_POPUP_LOCAL_STORAGE } from '../graph-constants';
 import { changePopUp } from './permission-mode-action-creator';
 import {
   anonymousRequest, authenticatedRequest,
@@ -119,15 +119,16 @@ async function createHistory(response: Response, respHeaders: any, query: IQuery
   return result;
 }
 
-export function checkTeamsAppInstallation(query: IQuery): Function {
+export function toggleRSCPopup(query: IQuery): Function {
   return (dispatch: Function, getState: Function) => {
     const tokenPresent = !!getState()?.authToken?.token;
     const respHeaders: any = {};
 
-    if (tokenPresent) {
+    if (tokenPresent && localStorage.getItem(RSC_HIDE_POPUP_LOCAL_STORAGE) !== "true") {
       return authenticatedRequest(dispatch, query).then(async (response: Response) => {
         const result = await parseResponse(response, respHeaders);
         for (const i of result.value) {
+          // check if Sample Teams App is installed
           if (i.teamsApp.externalId === TEAMS_APP_ID) {
             if (!getState().hideDialog) {
               dispatch(changePopUp(true));

--- a/src/app/services/actions/query-action-creators.ts
+++ b/src/app/services/actions/query-action-creators.ts
@@ -4,7 +4,7 @@ import { IHistoryItem } from '../../../types/history';
 import { IQuery } from '../../../types/query-runner';
 import { IStatus } from '../../../types/status';
 import { writeHistoryData } from '../../views/sidebar/history/history-utils';
-import { TEAMS_APP_ID, RSC_HIDE_POPUP_LOCAL_STORAGE } from '../graph-constants';
+import { TEAMS_APP_ID, RSC_HIDE_POPUP } from '../graph-constants';
 import { changePopUp } from './permission-mode-action-creator';
 import {
   anonymousRequest, authenticatedRequest,
@@ -124,7 +124,7 @@ export function toggleRSCPopup(query: IQuery): Function {
     const tokenPresent = !!getState()?.authToken?.token;
     const respHeaders: any = {};
 
-    if (tokenPresent && localStorage.getItem(RSC_HIDE_POPUP_LOCAL_STORAGE) !== "true") {
+    if (tokenPresent && localStorage.getItem(RSC_HIDE_POPUP) !== "true") {
       return authenticatedRequest(dispatch, query).then(async (response: Response) => {
         const result = await parseResponse(response, respHeaders);
         for (const i of result.value) {

--- a/src/app/services/graph-constants.ts
+++ b/src/app/services/graph-constants.ts
@@ -17,7 +17,7 @@ export enum PERMISSION_MODE_TYPE {
 }
 export const RSC_PERMISSIONS_ENDINGS = [".Group", ".Chat"];
 export const RSC_URL = "https://docs.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/resource-specific-consent";
-export const RSC_HIDE_POPUP_LOCAL_STORAGE = "do not show RSC popup again"
+export const RSC_HIDE_POPUP = "do not show RSC popup again"
 export const APP_IMAGE = "https://docs.microsoft.com/en-us/microsoftteams/platform/assets/icons/graph-icon-1.png";
 export const TEAMS_APP_ID = "46c88300-12bd-44cb-b3ba-734ed25fe1de";
 export const TEAMS_APP_URL = "https://www.bing.com/?form=000010";

--- a/src/app/services/graph-constants.ts
+++ b/src/app/services/graph-constants.ts
@@ -17,6 +17,7 @@ export enum PERMISSION_MODE_TYPE {
 }
 export const RSC_PERMISSIONS_ENDINGS = [".Group", ".Chat"];
 export const RSC_URL = "https://docs.microsoft.com/en-us/microsoftteams/platform/graph-api/rsc/resource-specific-consent";
+export const RSC_HIDE_POPUP_LOCAL_STORAGE = "do not show RSC popup again"
 export const APP_IMAGE = "https://docs.microsoft.com/en-us/microsoftteams/platform/assets/icons/graph-icon-1.png";
 export const TEAMS_APP_ID = "46c88300-12bd-44cb-b3ba-734ed25fe1de";
 export const TEAMS_APP_URL = "https://www.bing.com/?form=000010";

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -24,7 +24,7 @@ import { clearTermsOfUse } from '../services/actions/terms-of-use-action-creator
 import { changeThemeSuccess } from '../services/actions/theme-action-creator';
 import { toggleSidebar } from '../services/actions/toggle-sidebar-action-creator';
 import { changePopUp } from '../services/actions/permission-mode-action-creator';
-import { GRAPH_URL, PERMISSION_MODE_TYPE, RSC_URL, TEAMS_APP_URL, RSC_HIDE_POPUP_LOCAL_STORAGE } from '../services/graph-constants';
+import { GRAPH_URL, PERMISSION_MODE_TYPE, RSC_URL, TEAMS_APP_URL, RSC_HIDE_POPUP } from '../services/graph-constants';
 import { parseSampleUrl } from '../utils/sample-url-generation';
 import { substituteTokens } from '../utils/token-helpers';
 import { translateMessage } from '../utils/translate-messages';
@@ -298,7 +298,7 @@ class App extends Component<IAppProps, IAppState> {
   };
 
   private setRSCPopupDontShowAgain = () => {
-    localStorage.setItem(RSC_HIDE_POPUP_LOCAL_STORAGE, "true")
+    localStorage.setItem(RSC_HIDE_POPUP, "true")
   }
 
   public displayAuthenticationSection = (minimised: boolean) => {

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -1,6 +1,6 @@
 import {
   Announced,
-  IStackTokens, ITheme, styled, Dialog, DialogFooter, PrimaryButton, DefaultButton
+  IStackTokens, ITheme, styled, Dialog, DialogFooter, PrimaryButton, DefaultButton, Checkbox
 } from 'office-ui-fabric-react';
 import React, { Component } from 'react';
 import { InjectedIntl, injectIntl } from 'react-intl';
@@ -24,7 +24,7 @@ import { clearTermsOfUse } from '../services/actions/terms-of-use-action-creator
 import { changeThemeSuccess } from '../services/actions/theme-action-creator';
 import { toggleSidebar } from '../services/actions/toggle-sidebar-action-creator';
 import { changePopUp } from '../services/actions/permission-mode-action-creator';
-import { GRAPH_URL, PERMISSION_MODE_TYPE, RSC_URL, TEAMS_APP_URL } from '../services/graph-constants';
+import { GRAPH_URL, PERMISSION_MODE_TYPE, RSC_URL, TEAMS_APP_URL, RSC_HIDE_POPUP_LOCAL_STORAGE } from '../services/graph-constants';
 import { parseSampleUrl } from '../utils/sample-url-generation';
 import { substituteTokens } from '../utils/token-helpers';
 import { translateMessage } from '../utils/translate-messages';
@@ -69,6 +69,7 @@ interface IAppProps {
 interface IAppState {
   selectedVerb: string;
   mobileScreen: boolean;
+  hideRSCPopupValue: boolean;
 }
 
 class App extends Component<IAppProps, IAppState> {
@@ -78,7 +79,8 @@ class App extends Component<IAppProps, IAppState> {
     super(props);
     this.state = {
       selectedVerb: 'GET',
-      mobileScreen: false
+      mobileScreen: false,
+      hideRSCPopupValue: false,
     };
   }
 
@@ -287,8 +289,17 @@ class App extends Component<IAppProps, IAppState> {
   private toggleDialog = (): void => {
     const { hideDialog }: any = this.props;
     this.props.actions!.changePopUp(!hideDialog);
-
   };
+
+  private toggleHideRSCPopupValue = () => {
+    this.setState({
+      hideRSCPopupValue: !this.state.hideRSCPopupValue
+    });
+  };
+
+  private setRSCPopupDontShowAgain = () => {
+    localStorage.setItem(RSC_HIDE_POPUP_LOCAL_STORAGE, "true")
+  }
 
   public displayAuthenticationSection = (minimised: boolean) => {
     return <div style={{
@@ -328,6 +339,14 @@ class App extends Component<IAppProps, IAppState> {
       padding: 10
     };
 
+    const handleInstallTeamsAppButton = () => {
+      if (this.state.hideRSCPopupValue) {
+        this.setRSCPopupDontShowAgain();
+      }
+      this.toggleDialog();
+      window.open(TEAMS_APP_URL, '_blank')
+    }
+
     let sidebarWidth = `col-sm-12 col-lg-3 col-md-4 ${classes.sidebar}`;
 
     let layout =
@@ -355,8 +374,9 @@ class App extends Component<IAppProps, IAppState> {
           }}
           onDismiss={this.toggleDialog}
         >
+          <Checkbox label={translateMessage('Do not show again')} checked={this.state.hideRSCPopupValue} onChange={() => this.toggleHideRSCPopupValue()} />
           <DialogFooter>
-            <PrimaryButton onClick={() => window.open(TEAMS_APP_URL, '_blank')} text={translateMessage('Install')} />
+            <PrimaryButton onClick={handleInstallTeamsAppButton} text={translateMessage('Install')} />
             <DefaultButton onClick={() => window.open(RSC_URL, '_blank')} text={translateMessage('Learn more')} />
           </DialogFooter>
         </Dialog>}

--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -32,7 +32,7 @@ import { changeTheme } from '../../services/actions/theme-action-creator';
 import { Permission } from '../query-runner/request/permissions';
 import { translateMessage } from '../../utils/translate-messages';
 import { PERMISSION_MODE_TYPE } from '../../services/graph-constants';
-import { checkTeamsAppInstallation } from '../../services/actions/query-action-creators'
+import { toggleRSCPopup } from '../../services/actions/query-action-creators'
 import { IQuery } from '../../../types/query-runner';
 
 
@@ -141,7 +141,7 @@ function Settings(props: ISettingsProps) {
     let newPermissionModeType;
     switch (permissionModeType) {
       case PERMISSION_MODE_TYPE.User:
-        dispatch(checkTeamsAppInstallation(query));
+        dispatch(toggleRSCPopup(query));
         dispatch(changeMode(PERMISSION_MODE_TYPE.TeamsApp));
         break;
       case PERMISSION_MODE_TYPE.TeamsApp:

--- a/src/messages/GE.json
+++ b/src/messages/GE.json
@@ -363,5 +363,6 @@
   "Install": "Install",
   "Install sample app": "Install sample app",
   "Learn more": "Learn more",
+  "Do not show again": "Don't show again",
   "App mode access token error": "Access token is hidden in application mode for security purposes."
 }


### PR DESCRIPTION
## Overview

Adds a **Don't show again** checkbox which saves a flag into localStorage specifying that the user would not like to see the RSC popup again. The flag persists when the user hits Install button in the RSC popup with the checkbox checked. 

Note the PR is to merge against interns/acchiang/39140-update-rsc-popup, but once that branch is merged into interns/dev in PR #42 we will be PRing this branch against interns/dev. 

### Demo
![image](https://user-images.githubusercontent.com/47487758/126403784-56ec2652-93e3-48ef-ba35-28671fff33de.png)
https://gyazo.com/ce86d57524261212199de0f428727969

## Testing Instructions

* If you have already hit **Don't show again** and then the Install button (as showed in the demo GIF), you can unset the localStorage flag by going into the browser dev tools console, entering `localStorage.removeItem("do not show RSC popup again")`, and hitting enter. Make sure to also refresh the page after in order to refresh the local states controlling the local state controlling the **Don't show again** checkbox's checked state. 
* Log in, go to More options and select Use Graph Explorer as a sample Teams application. **Verify:** The popup should appear. 
* Go to More options again and select Use Graph Explorer as a signed-in user. **Verify:** The popup should not appear. 
* Go to More options again and select Use Graph Explorer as a sample Teams application. **Verify:** The popup should not appear. 
