### PR TITLE
AB#39309 add translated aria message to copy icon

### DIFF
--- a/src/app/views/query-runner/request/auth/Auth.tsx
+++ b/src/app/views/query-runner/request/auth/Auth.tsx
@@ -67,7 +67,7 @@ export function Auth(props: any) {
           <Label className={classes.accessTokenLabel}><FormattedMessage id='Access Token' /></Label>
           {(permissionModeType === PERMISSION_MODE_TYPE.User) &&
             <div>
-              <IconButton onClick={handleCopy} iconProps={copyIcon} title='Copy' ariaLabel='Copy' />
+              <IconButton onClick={handleCopy} iconProps={copyIcon} title={translateMessage('Copy')} ariaLabel={translateMessage('Copy')} />
               <IconButton iconProps={tokenDetailsIcon}
                 title={translateMessage('Get token details (Powered by jwt.ms)')}
                 ariaLabel={translateMessage('Get token details (Powered by jwt.ms)')}


### PR DESCRIPTION
## Overview

I did a full sweep of all the components we have added to the Graph Explorer by making a draft PR of LokiLabs:interns/dev against MSGraph:dev, and then found all the non-text-based components we added that were missing translated aria labels. Turns out it was not that many that needed updates. 
