### PR TITLE
Fix: Sandbox Query Runner Infinite Load (Async timeout bug)

### DIFF
--- a/src/app/views/settings/Settings.tsx
+++ b/src/app/views/settings/Settings.tsx
@@ -141,8 +141,8 @@ function Settings(props: ISettingsProps) {
     let newPermissionModeType = PERMISSION_MODE_TYPE.TeamsApp;
     switch (permissionModeType) {
       case PERMISSION_MODE_TYPE.User:
-        dispatch(changeMode(newPermissionModeType));
         dispatch(toggleRSCPopup(query));
+        dispatch(changeMode(newPermissionModeType));
         break;
       case PERMISSION_MODE_TYPE.TeamsApp:
         newPermissionModeType = PERMISSION_MODE_TYPE.User;


### PR DESCRIPTION
Run a query in sandbox (logged out) mode; This PR should mean that it does not timeout / infinitely load.
Make sure that the teams app mode also does not time out, otherwise this would be creating a new bug.

Reference PR: #51 

[AD#39556](https://dev.azure.com/microsoftgarage/Intern%20GitHub/_sprints/taskboard/GI21%20-%20Graph%20Explorer/Intern%20GitHub/Y21-S/09?workitem=39556)