### PR TITLE
AB#39089 Adaptive cards response side by side

### DIFF
--- a/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
+++ b/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
@@ -100,68 +100,26 @@ class AdaptiveCard extends Component<IAdaptiveCardProps> {
         this.adaptiveCard!.parse(data.card);
         const renderedCard = this.adaptiveCard!.render();
         return (
-          <Pivot className='pivot-response' onLinkClick={(pivotItem) => onPivotItemClick(sampleQuery, pivotItem)}>
-            <PivotItem
-              itemKey='card'
-              ariaLabel={translateMessage('card')}
-              headerText={translateMessage('card')}
-              className={classes.card}
-            >
-              <div
-                ref={(n) => {
-                  if (n && !n.firstChild) {
-                    n.appendChild(renderedCard);
-                  } else {
-                    if (n && n.firstChild) {
-                      n.replaceChild(renderedCard, n.firstChild);
-                    }
+          <div className={classes.container}>
+            <div className={classes.column}
+              ref={(n) => {
+                if (n && !n.firstChild) {
+                  n.appendChild(renderedCard);
+                } else {
+                  if (n && n.firstChild) {
+                    n.replaceChild(renderedCard, n.firstChild);
                   }
-                }}
-              />
-            </PivotItem>
-            <PivotItem
-              itemKey='JSON-schema'
-              ariaLabel={translateMessage('JSON Schema')}
-              headerText={translateMessage('JSON Schema')}
-            >
-              <MessageBar messageBarType={MessageBarType.info}>
-                <FormattedMessage id='Get started with adaptive cards on' />
-                <a href={'https://docs.microsoft.com/en-us/adaptive-cards/templating/sdk'}
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  tabIndex={0}
-                  className={classes.link}
-                >
-                  <FormattedMessage id='Adaptive Cards Templating SDK' />
-                </a>
-                <FormattedMessage id='and experiment on' />
-                <a href={'https://adaptivecards.io/designer/'}
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  tabIndex={0}
-                  className={classes.link}
-                >
-                  <FormattedMessage id='Adaptive Cards designer' />
-                </a>
-              </MessageBar>
-              <IconButton className={classes.copyIcon}
-                ariaLabel={translateMessage('Copy')}
-                iconProps={{
-                  iconName: 'copy',
-                }}
-                onClick={async () =>
-                  trackedGenericCopy(
-                    JSON.stringify(data.template, null, 4),
-                    componentNames.JSON_SCHEMA_COPY_BUTTON,
-                    sampleQuery)}
-              />
+                }
+              }}
+            />
+            <div className={classes.column}>
               <Monaco
                 language='json'
                 body={data.template}
                 height={'800px'}
               />
-            </PivotItem>
-          </Pivot>
+            </div>
+          </div>
         );
       } catch (err) {
         return <div style={{ color: 'red' }}>{err.message}</div>;

--- a/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
+++ b/src/app/views/query-response/adaptive-cards/AdaptiveCard.tsx
@@ -1,5 +1,5 @@
 import * as AdaptiveCardsAPI from 'adaptivecards';
-import { IconButton, Label, MessageBar, MessageBarType, Pivot, PivotItem, styled } from 'office-ui-fabric-react';
+import { IconButton, Label, MessageBar, MessageBarType, styled } from 'office-ui-fabric-react';
 import React, { Component } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
@@ -7,7 +7,6 @@ import { bindActionCreators, Dispatch } from 'redux';
 
 import { componentNames, telemetry } from '../../../../telemetry';
 import { IAdaptiveCardProps } from '../../../../types/adaptivecard';
-import { IQuery } from '../../../../types/query-runner';
 import { IRootState } from '../../../../types/root';
 import { getAdaptiveCard } from '../../../services/actions/adaptive-cards-action-creator';
 import { translateMessage } from '../../../utils/translate-messages';
@@ -100,24 +99,63 @@ class AdaptiveCard extends Component<IAdaptiveCardProps> {
         this.adaptiveCard!.parse(data.card);
         const renderedCard = this.adaptiveCard!.render();
         return (
-          <div className={classes.container}>
-            <div className={classes.column}
-              ref={(n) => {
-                if (n && !n.firstChild) {
-                  n.appendChild(renderedCard);
-                } else {
-                  if (n && n.firstChild) {
-                    n.replaceChild(renderedCard, n.firstChild);
+          <div>
+            <div className={classes.container}>
+              <div className={classes.column}>
+                <MessageBar messageBarType={MessageBarType.info}>
+                  <FormattedMessage id='Get started with adaptive cards on' />
+                  <a href={'https://docs.microsoft.com/en-us/adaptive-cards/templating/sdk'}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    tabIndex={0}
+                    className={classes.link}
+                  >
+                    <FormattedMessage id='Adaptive Cards Templating SDK' />
+                  </a>
+                  <FormattedMessage id='and experiment on' />
+                  <a href={'https://adaptivecards.io/designer/'}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    tabIndex={0}
+                    className={classes.link}
+                  >
+                    <FormattedMessage id='Adaptive Cards designer' />
+                  </a>
+                </MessageBar>
+              </div>
+              <div className={classes.columnicon} >
+                <IconButton className={classes.copyIcon}
+                  ariaLabel={translateMessage('Copy')}
+                  iconProps={{
+                    iconName: 'copy',
+                  }}
+                  onClick={async () =>
+                    trackedGenericCopy(
+                      JSON.stringify(data.template, null, 4),
+                      componentNames.JSON_SCHEMA_COPY_BUTTON,
+                      sampleQuery)}
+                />
+              </div>
+            </div>
+            <div className={classes.container}>
+              <div className={classes.column}
+                ref={(n) => {
+                  if (n && !n.firstChild) {
+                    n.appendChild(renderedCard);
+                  } else {
+                    if (n && n.firstChild) {
+                      n.replaceChild(renderedCard, n.firstChild);
+                    }
                   }
-                }
-              }}
-            />
-            <div className={classes.column}>
-              <Monaco
-                language='json'
-                body={data.template}
-                height={'800px'}
+                }}
               />
+              <div className={classes.monacoColumn}>
+                <Monaco
+                  language='json'
+                  body={data.template}
+                  height={'800px'}
+                />
+              </div>
             </div>
           </div>
         );
@@ -125,14 +163,6 @@ class AdaptiveCard extends Component<IAdaptiveCardProps> {
         return <div style={{ color: 'red' }}>{err.message}</div>;
       }
     }
-  }
-}
-
-function onPivotItemClick(query: IQuery | undefined, item?: PivotItem) {
-  if (!item) { return; }
-  const key = item.props.itemKey;
-  if (key) {
-    telemetry.trackTabClickEvent(key, query);
   }
 }
 

--- a/src/app/views/query-response/queryResponse.styles.ts
+++ b/src/app/views/query-response/queryResponse.styles.ts
@@ -25,8 +25,7 @@ export const queryResponseStyles = (theme: ITheme) => {
       overflowY: 'auto'
     },
     copyIcon: {
-      float: 'right',
-      zIndex: 1
+      float: 'right'
     },
     container: {
       display: 'flex',
@@ -37,8 +36,23 @@ export const queryResponseStyles = (theme: ITheme) => {
     column: {
       display: 'flex',
       flexDirection: 'column',
-      flexBasis: '100%',
+      flexBasis: '50%',
       flex: 1
+    },
+    columnicon: {
+      display: 'flex',
+      flexDirection: 'column',
+      flexBasis: '50%',
+      flex: 1,
+      maxWidth: 'fit-content'
+    },
+    monacoColumn: {
+      display: 'flex',
+      flexDirection: 'column',
+      flexBasis: '50%',
+      flex: 1,
+      maxWidth: '65vw',
+      minWidth: '40vw'
     }
   };
 };

--- a/src/app/views/query-response/queryResponse.styles.ts
+++ b/src/app/views/query-response/queryResponse.styles.ts
@@ -27,6 +27,18 @@ export const queryResponseStyles = (theme: ITheme) => {
     copyIcon: {
       float: 'right',
       zIndex: 1
+    },
+    container: {
+      display: 'flex',
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      wdith: '100%'
+    },
+    column: {
+      display: 'flex',
+      flexDirection: 'column',
+      flexBasis: '100%',
+      flex: 1
     }
   };
 };


### PR DESCRIPTION
## Overview

One of the pain points that needed to be addressed was having a button to switch between the card and its json template in the adaptive cards response. This PR puts them side by side so the user has an easier time.

### Demo

![image](https://user-images.githubusercontent.com/47064505/128395596-d5089550-b143-49dc-981c-c425cb33ba0a.png)

### Notes

I am pretty bad at CSS and I have a feeling that I did it in a hack-y way. It looks okay it different screens but I may have missed something

## Testing Instructions

* Checkout to this branch 
* Run the app 
* Run the initial defaulted /me query 
* Go to adaptive cards response 